### PR TITLE
feat: reader mode — full-screen distraction-free reading (1.5)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,8 +2,8 @@
 
 > Start here. This file orients each session.
 
-**Version:** v3.0 | **Status:** Full-text search shipped (Phase 1.3 complete)
-**Next up:** Import system (1.4) → Reader mode (1.5)
+**Version:** v3.0 | **Status:** Reader mode shipped (Phase 1.5 complete)
+**Next up:** Import system (1.4) — deferred
 **Active phase:** [Phase 1 — Foundation](plan/phase-1.md)
 
 ---
@@ -45,6 +45,7 @@ docs/
 │   ├── v3.0-content-extraction.md # 1.2b Content extraction pipeline
 │   ├── v3.0-areas-tagging-redesign.md # Areas & tagging two-tier model
 │   ├── v3.0-full-text-search.md    # 1.3 Full-text search
+│   ├── v3.0-reader-mode.md         # 1.5 Reader mode
 │   └── v3.0-testing-ci.md         # 1.6 Testing & CI (Vitest + GitHub Actions)
 ├── guides/                         # How-to references
 │   ├── workflow.md                 # Development practices, session workflow
@@ -60,6 +61,7 @@ docs/
 
 | Version | Feature | Log |
 |---|---|---|
+| v3.0 | Reader mode (full-screen, typography controls, progress, sepia theme) | [log/v3.0-reader-mode.md](log/v3.0-reader-mode.md) |
 | v3.0 | Full-text search (excerpt + content.text, debounce, result count, tsvector) | [log/v3.0-full-text-search.md](log/v3.0-full-text-search.md) |
 | v3.0 | Testing & CI (Vitest 95 tests, GitHub Actions pipeline) | [log/v3.0-testing-ci.md](log/v3.0-testing-ci.md) |
 | v3.0 | Areas & tagging redesign (two-tier model, junction table, AI-aware) | [log/v3.0-areas-tagging-redesign.md](log/v3.0-areas-tagging-redesign.md) |

--- a/docs/log/v3.0-reader-mode.md
+++ b/docs/log/v3.0-reader-mode.md
@@ -1,0 +1,77 @@
+# v3.0 — Reader Mode (1.5)
+
+**Date:** 2026-02-18
+**PR:** #10 (feat/6-reader-mode → main)
+**Issue:** #6
+
+---
+
+## What was built
+
+A full-screen, distraction-free reading overlay that renders extracted article content from the `content.text` field. Triggered from the DetailPanel when `content_status === 'success'`.
+
+### Features
+- **Full-screen overlay** (z-60) — covers both mobile slide-up panel and desktop sidebar
+- **Reading progress bar** — 2px bar at top tracks scroll progress (0–100%)
+- **Typography controls** — font size (S/M/L), font family (sans/serif), reader theme (light/dark/sepia)
+- **Persisted preferences** — `useReaderPrefs` hook stores to `localStorage` key `reader_prefs`
+- **Reading meta** — author, reading time, word count rendered below article title
+- **Minutes remaining** — calculated from scroll position × word count ÷ 238 WPM
+- **Status action** — "Start Reading" (unread→reading), "Mark Done" (reading→done), or "✓ Done" indicator
+- **Accessibility** — `role="dialog"`, `aria-modal`, `aria-label`, ESC to close, 44px touch targets
+- **Paragraph rendering** — `content.text.split(/\n{2,}/)` → `<p>` tags with `leading-relaxed`
+
+### "Read" button in DetailPanel
+- Shows when `content_status === 'success' && content?.text` exists (enabled)
+- Shows disabled when `content_status === 'pending' | 'extracting'`
+- Hidden when `content_status === 'failed' | 'skipped'`
+- Added to both mobile (slide-up) and desktop (right sidebar) layouts
+
+---
+
+## Files changed
+
+**Created:**
+- `src/hooks/useReaderPrefs.ts` — localStorage-backed typography preferences
+- `src/components/reader/ReaderModal.tsx` — full-screen reader overlay
+- `src/components/__tests__/ReaderModal.test.tsx` — 13 component tests
+
+**Modified:**
+- `src/components/detail/DetailPanel.tsx` — Read button + `showReader` state + `<ReaderModal>`
+- `src/lib/demo-data.ts` — added `content.text` to `demo-9` (Browser Design) and `demo-13` (useEffect); expanded `SAMPLE_CONTENT.text` for `demo-10` (Modular Monolith)
+- `public/sw.js` — bumped cache to `contentdeck-v3.0.5`
+
+---
+
+## Key decisions
+
+- **State in DetailPanel, not Dashboard** — `showReader` is local state inside `DetailPanel`. No prop drilling through Dashboard needed since `onCycleStatus` was already available in DetailPanel.
+- **Custom full-screen overlay vs reusing `Modal`** — the existing `Modal` component has max-height constraints (`max-h-[88vh]`). Reader mode needed a true full-screen experience, so a custom component was correct.
+- **Sepia theme** — Tailwind arbitrary values: `bg-[#f9f5ed] text-[#433422]`. No new CSS variables needed.
+- **Paragraph splitting** — `content.text.split(/\n{2,}/)` handles both Unix (single `\n\n`) and runs of blank lines. Single `\n` within a paragraph are preserved as `<br>`.
+- **Reading speed** — 238 WPM is the research-backed average silent reading speed. Used consistently for both initial "X min read" display and live "X min remaining" calculation.
+- **Three demo bookmarks with content** — `demo-9`, `demo-10`, `demo-13` now have `content_status: 'success'` with realistic extracted text, making reader mode fully demonstrable in demo mode.
+
+---
+
+## Test coverage
+
+13 new component tests in `ReaderModal.test.tsx`:
+- Renders title, paragraphs, author, word count, reading time
+- Shows "no content" when text is empty
+- Calls `onClose` on ESC key and close button
+- Shows correct status button per bookmark status (unread/reading/done)
+- Calls `onCycleStatus` with correct next status
+- Shows `✓ Done` indicator when status is already done
+- Shows progress bar element
+- Does not render when `open={false}`
+
+**Total tests:** 119 (was 106, +13)
+
+---
+
+## Gotchas
+
+- The `useReaderPrefs` hook reads localStorage in the state initializer, which runs once per mount. This is intentional — prefs update only on the next open after being changed in another session. Since the modal unmounts when closed, this is fine.
+- `document.body.style.overflow = 'hidden'` is set when the reader opens and cleaned up in the effect return. This prevents the underlying scroll from moving while the reader is active.
+- The `scrollHeight - clientHeight` calculation returns 0 for short content (content fits without scrolling). The handler guards against this with a `<= 0` check that sets progress to 1 immediately.

--- a/docs/plan/phase-1.md
+++ b/docs/plan/phase-1.md
@@ -2,7 +2,7 @@
 
 > Goal: Real users, real data, real reliability. The "production-grade" release.
 
-**Completed:** 1.1 Supabase Auth, 1.1a Bookmarklet, 1.1b iOS Shortcut, 1.2a Metadata fix, 1.2b Content extraction, Areas & tagging redesign, 1.3 Full-text search, 1.6 Testing & CI — see `docs/log/`
+**Completed:** 1.1 Supabase Auth, 1.1a Bookmarklet, 1.1b iOS Shortcut, 1.2a Metadata fix, 1.2b Content extraction, Areas & tagging redesign, 1.3 Full-text search, 1.5 Reader mode, 1.6 Testing & CI — see `docs/log/`
 
 ---
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'contentdeck-v3.0.4'
+const CACHE_NAME = 'contentdeck-v3.0.5'
 
 self.addEventListener('install', () => {
   // Don't skip waiting — let the app decide when to activate

--- a/src/components/__tests__/ReaderModal.test.tsx
+++ b/src/components/__tests__/ReaderModal.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ReaderModal from '../reader/ReaderModal';
+import type { Bookmark } from '../../types';
+
+// Stub localStorage
+const localStorageStore: Record<string, string> = {};
+vi.stubGlobal('localStorage', {
+  getItem: (k: string) => localStorageStore[k] ?? null,
+  setItem: (k: string, v: string) => {
+    localStorageStore[k] = v;
+  },
+  removeItem: (k: string) => {
+    delete localStorageStore[k];
+  },
+  clear: () => Object.keys(localStorageStore).forEach((k) => delete localStorageStore[k]),
+});
+
+function makeBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
+  return {
+    id: 'bm-1',
+    url: 'https://example.com/article',
+    title: 'Test Article Title',
+    image: null,
+    excerpt: 'A short excerpt.',
+    source_type: 'blog',
+    status: 'reading',
+    is_favorited: false,
+    notes: [],
+    tags: [],
+    areas: [],
+    metadata: {},
+    content: {
+      text: 'First paragraph of the article.\n\nSecond paragraph with more content.\n\nThird paragraph here.',
+      author: 'Jane Author',
+      word_count: 500,
+      reading_time: 2,
+    },
+    content_status: 'success',
+    content_fetched_at: new Date().toISOString(),
+    synced: false,
+    created_at: new Date().toISOString(),
+    status_changed_at: new Date().toISOString(),
+    started_reading_at: null,
+    finished_at: null,
+    ...overrides,
+  };
+}
+
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  onCycleStatus: vi.fn(),
+};
+
+describe('ReaderModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorageStore['reader_prefs'] = JSON.stringify({
+      fontSize: 'md',
+      fontFamily: 'sans',
+      theme: 'light',
+    });
+  });
+
+  it('renders the bookmark title', () => {
+    render(<ReaderModal bookmark={makeBookmark()} {...defaultProps} />);
+    // Title appears in both header and article heading
+    expect(screen.getAllByText('Test Article Title').length).toBeGreaterThan(0);
+  });
+
+  it('renders extracted content as separate paragraphs', () => {
+    render(<ReaderModal bookmark={makeBookmark()} {...defaultProps} />);
+    expect(screen.getByText('First paragraph of the article.')).toBeInTheDocument();
+    expect(screen.getByText('Second paragraph with more content.')).toBeInTheDocument();
+    expect(screen.getByText('Third paragraph here.')).toBeInTheDocument();
+  });
+
+  it('shows author and reading time metadata', () => {
+    render(<ReaderModal bookmark={makeBookmark()} {...defaultProps} />);
+    expect(screen.getByText('Jane Author')).toBeInTheDocument();
+    expect(screen.getByText('2 min read')).toBeInTheDocument();
+  });
+
+  it('shows word count in metadata', () => {
+    render(<ReaderModal bookmark={makeBookmark()} {...defaultProps} />);
+    expect(screen.getByText('500 words')).toBeInTheDocument();
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn();
+    render(<ReaderModal bookmark={makeBookmark()} {...defaultProps} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /close reader/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when Escape key is pressed', () => {
+    const onClose = vi.fn();
+    render(<ReaderModal bookmark={makeBookmark()} {...defaultProps} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows "Mark Done" button when status is reading', () => {
+    render(<ReaderModal bookmark={makeBookmark({ status: 'reading' })} {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /mark done/i })).toBeInTheDocument();
+  });
+
+  it('shows "Start Reading" button when status is unread', () => {
+    render(<ReaderModal bookmark={makeBookmark({ status: 'unread' })} {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /start reading/i })).toBeInTheDocument();
+  });
+
+  it('calls onCycleStatus with done when Mark Done is clicked', () => {
+    const onCycleStatus = vi.fn();
+    render(
+      <ReaderModal
+        bookmark={makeBookmark({ status: 'reading' })}
+        {...defaultProps}
+        onCycleStatus={onCycleStatus}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /mark done/i }));
+    expect(onCycleStatus).toHaveBeenCalledWith('bm-1', 'done');
+  });
+
+  it('shows Done indicator when status is already done', () => {
+    render(<ReaderModal bookmark={makeBookmark({ status: 'done' })} {...defaultProps} />);
+    expect(screen.getByText('✓ Done')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /mark done/i })).not.toBeInTheDocument();
+  });
+
+  it('shows "no content" message when content text is empty', () => {
+    render(
+      <ReaderModal bookmark={makeBookmark({ content: { word_count: 0 } })} {...defaultProps} />,
+    );
+    expect(screen.getByText('No extracted content available.')).toBeInTheDocument();
+  });
+
+  it('shows a reading progress bar', () => {
+    render(<ReaderModal bookmark={makeBookmark()} {...defaultProps} />);
+    // Progress bar is present (starts at 0 width)
+    const progressBar = document.querySelector('[style*="width:"]');
+    expect(progressBar).toBeInTheDocument();
+  });
+
+  it('does not render when open is false', () => {
+    render(<ReaderModal bookmark={makeBookmark()} {...defaultProps} open={false} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/detail/DetailPanel.tsx
+++ b/src/components/detail/DetailPanel.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useCallback } from 'react';
-import { X } from 'lucide-react';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { X, BookOpen } from 'lucide-react';
 import MetadataHeader from './MetadataHeader';
 import NotesTab from './NotesTab';
 import DetailActions from './DetailActions';
+import ReaderModal from '../reader/ReaderModal';
 import type { Bookmark, Status, NoteType } from '../../types';
 
 interface DetailPanelProps {
@@ -34,6 +35,7 @@ export default function DetailPanel({
   isNotePending,
   isRefreshing,
 }: DetailPanelProps) {
+  const [showReader, setShowReader] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
 
@@ -53,6 +55,10 @@ export default function DetailPanel({
 
   if (!bookmark) return null;
 
+  const canRead = bookmark.content_status === 'success' && !!bookmark.content?.text;
+  const isExtracting =
+    bookmark.content_status === 'pending' || bookmark.content_status === 'extracting';
+
   function handleDelete() {
     if (confirm('Delete this bookmark?')) {
       onDelete(bookmark!.id);
@@ -62,6 +68,14 @@ export default function DetailPanel({
 
   return (
     <>
+      {/* Reader Modal — covers everything */}
+      <ReaderModal
+        bookmark={bookmark}
+        open={showReader}
+        onClose={() => setShowReader(false)}
+        onCycleStatus={onCycleStatus}
+      />
+
       {/* Mobile: full-screen slide-up overlay */}
       <div
         ref={overlayRef}
@@ -100,6 +114,17 @@ export default function DetailPanel({
               onRefreshMetadata={onRefreshMetadata}
               isRefreshing={isRefreshing}
             />
+            {(canRead || isExtracting) && (
+              <button
+                onClick={() => setShowReader(true)}
+                disabled={!canRead}
+                className="w-full flex items-center justify-center gap-2 py-2.5 rounded-lg bg-primary-600 text-white text-sm font-medium hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors min-h-[44px]"
+                aria-label={isExtracting ? 'Extracting content…' : 'Open reader mode'}
+              >
+                <BookOpen size={16} />
+                {isExtracting ? 'Extracting…' : 'Read'}
+              </button>
+            )}
             <NotesTab
               notes={bookmark.notes}
               onAddNote={(type, content) => onAddNote(bookmark.id, type, content)}
@@ -143,6 +168,17 @@ export default function DetailPanel({
             onRefreshMetadata={onRefreshMetadata}
             isRefreshing={isRefreshing}
           />
+          {(canRead || isExtracting) && (
+            <button
+              onClick={() => setShowReader(true)}
+              disabled={!canRead}
+              className="w-full flex items-center justify-center gap-2 py-2.5 rounded-lg bg-primary-600 text-white text-sm font-medium hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors min-h-[44px]"
+              aria-label={isExtracting ? 'Extracting content…' : 'Open reader mode'}
+            >
+              <BookOpen size={16} />
+              {isExtracting ? 'Extracting…' : 'Read'}
+            </button>
+          )}
           <NotesTab
             notes={bookmark.notes}
             onAddNote={(type, content) => onAddNote(bookmark.id, type, content)}

--- a/src/components/reader/ReaderModal.tsx
+++ b/src/components/reader/ReaderModal.tsx
@@ -1,0 +1,286 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { X, BookOpen, Type } from 'lucide-react';
+import { useReaderPrefs } from '../../hooks/useReaderPrefs';
+import type { Bookmark, Status } from '../../types';
+import { STATUS_NEXT } from '../../types';
+
+interface ReaderModalProps {
+  bookmark: Bookmark;
+  open: boolean;
+  onClose: () => void;
+  onCycleStatus: (id: string, newStatus: Status) => void;
+}
+
+const FONT_SIZE_CLASSES = {
+  sm: 'text-sm',
+  md: 'text-base',
+  lg: 'text-lg',
+} as const;
+
+const FONT_FAMILY_CLASSES = {
+  sans: 'font-sans',
+  serif: 'font-serif',
+} as const;
+
+// Approx. average reading speed in words per minute
+const WPM = 238;
+
+function getThemeClasses(theme: 'light' | 'dark' | 'sepia'): string {
+  switch (theme) {
+    case 'dark':
+      return 'bg-surface-950 text-surface-100';
+    case 'sepia':
+      return 'bg-[#f9f5ed] text-[#433422]';
+    default:
+      return 'bg-white text-surface-900';
+  }
+}
+
+function getHeaderThemeClasses(theme: 'light' | 'dark' | 'sepia'): string {
+  switch (theme) {
+    case 'dark':
+      return 'bg-surface-950 border-surface-800 text-surface-100';
+    case 'sepia':
+      return 'bg-[#f0ebe0] border-[#d6ccb4] text-[#433422]';
+    default:
+      return 'bg-white border-surface-200 text-surface-900';
+  }
+}
+
+export default function ReaderModal({ bookmark, open, onClose, onCycleStatus }: ReaderModalProps) {
+  const { fontSize, fontFamily, theme, update } = useReaderPrefs();
+  const [scrollProgress, setScrollProgress] = useState(0);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (open) {
+      document.addEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = 'hidden';
+    }
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = '';
+    };
+  }, [open, handleKeyDown]);
+
+  // Reset scroll when bookmark changes
+  useEffect(() => {
+    if (open && contentRef.current) {
+      contentRef.current.scrollTop = 0;
+      setScrollProgress(0);
+    }
+  }, [open, bookmark.id]);
+
+  if (!open) return null;
+
+  const contentText = bookmark.content?.text ?? '';
+  const paragraphs = contentText.split(/\n{2,}/).filter(Boolean);
+  const wordCount = bookmark.content?.word_count ?? 0;
+  const readingTime =
+    bookmark.content?.reading_time ?? (wordCount > 0 ? Math.ceil(wordCount / WPM) : null);
+  const author = bookmark.content?.author;
+
+  const wordsRemaining = Math.ceil((1 - scrollProgress) * wordCount);
+  const minutesRemaining = wordCount > 0 ? Math.ceil(wordsRemaining / WPM) : null;
+
+  function handleScroll() {
+    const el = contentRef.current;
+    if (!el) return;
+    const scrollable = el.scrollHeight - el.clientHeight;
+    if (scrollable <= 0) {
+      setScrollProgress(1);
+      return;
+    }
+    setScrollProgress(Math.min(el.scrollTop / scrollable, 1));
+  }
+
+  const themeClasses = getThemeClasses(theme);
+  const headerThemeClasses = getHeaderThemeClasses(theme);
+  const fontSizeClass = FONT_SIZE_CLASSES[fontSize];
+  const fontFamilyClass = FONT_FAMILY_CLASSES[fontFamily];
+
+  const statusNext = STATUS_NEXT[bookmark.status];
+
+  return (
+    <div
+      className={`fixed inset-0 z-[60] flex flex-col ${themeClasses}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Reading: ${bookmark.title ?? 'Article'}`}
+    >
+      {/* Progress bar */}
+      <div className="h-0.5 w-full bg-transparent">
+        <div
+          className="h-full bg-primary-600 transition-all duration-150"
+          style={{ width: `${scrollProgress * 100}%` }}
+          aria-hidden="true"
+        />
+      </div>
+
+      {/* Header */}
+      <header
+        className={`flex items-center justify-between gap-3 px-4 py-2 border-b ${headerThemeClasses} shrink-0`}
+      >
+        {/* Left: icon + title */}
+        <div className="flex items-center gap-2 min-w-0">
+          <BookOpen size={16} className="text-primary-600 shrink-0" aria-hidden="true" />
+          <span className="text-sm font-medium truncate max-w-[200px] sm:max-w-xs">
+            {bookmark.title ?? 'Article'}
+          </span>
+        </div>
+
+        {/* Controls */}
+        <div className="flex items-center gap-1 shrink-0">
+          {/* Font size */}
+          <div className="flex items-center gap-0.5" aria-label="Font size">
+            {(['sm', 'md', 'lg'] as const).map((size) => (
+              <button
+                key={size}
+                onClick={() => update({ fontSize: size })}
+                className={`px-1.5 py-1 rounded text-xs font-medium min-w-[28px] min-h-[36px] flex items-center justify-center transition-colors ${
+                  fontSize === size
+                    ? 'bg-primary-600 text-white'
+                    : theme === 'dark'
+                      ? 'text-surface-400 hover:bg-surface-800'
+                      : 'text-surface-500 hover:bg-surface-100'
+                }`}
+                aria-label={`Font size ${size}`}
+                aria-pressed={fontSize === size}
+              >
+                {size === 'sm' ? 'A' : size === 'md' ? 'A' : 'A'}
+              </button>
+            ))}
+          </div>
+
+          {/* Font family */}
+          <button
+            onClick={() => update({ fontFamily: fontFamily === 'sans' ? 'serif' : 'sans' })}
+            className={`px-2 py-1 rounded text-xs font-medium min-w-[36px] min-h-[36px] flex items-center justify-center transition-colors ${
+              fontFamily === 'serif'
+                ? 'bg-primary-600 text-white'
+                : theme === 'dark'
+                  ? 'text-surface-400 hover:bg-surface-800'
+                  : 'text-surface-500 hover:bg-surface-100'
+            }`}
+            aria-label={`Font family: ${fontFamily === 'sans' ? 'switch to serif' : 'switch to sans-serif'}`}
+            aria-pressed={fontFamily === 'serif'}
+          >
+            <Type size={13} />
+          </button>
+
+          {/* Theme swatches */}
+          <div className="flex items-center gap-0.5 ml-1" aria-label="Reader theme">
+            {(['light', 'dark', 'sepia'] as const).map((t) => (
+              <button
+                key={t}
+                onClick={() => update({ theme: t })}
+                className={`w-6 h-6 rounded-full border-2 transition-all min-w-[28px] min-h-[28px] flex items-center justify-center ${
+                  theme === t ? 'border-primary-600 scale-110' : 'border-surface-300'
+                }`}
+                style={{
+                  backgroundColor: t === 'light' ? '#ffffff' : t === 'dark' ? '#0a0a0f' : '#f9f5ed',
+                }}
+                aria-label={`${t} theme`}
+                aria-pressed={theme === t}
+              />
+            ))}
+          </div>
+
+          {/* Close */}
+          <button
+            onClick={onClose}
+            className={`ml-2 p-2 rounded-lg min-w-[40px] min-h-[40px] flex items-center justify-center transition-colors ${
+              theme === 'dark' ? 'hover:bg-surface-800' : 'hover:bg-surface-100'
+            }`}
+            aria-label="Close reader"
+          >
+            <X size={18} />
+          </button>
+        </div>
+      </header>
+
+      {/* Content */}
+      <div ref={contentRef} className="flex-1 overflow-y-auto" onScroll={handleScroll}>
+        <div className={`max-w-2xl mx-auto px-6 py-10 ${fontSizeClass} ${fontFamilyClass}`}>
+          {/* Article header */}
+          <h1 className="text-2xl sm:text-3xl font-bold leading-tight mb-4">
+            {bookmark.title ?? 'Untitled'}
+          </h1>
+
+          {/* Meta */}
+          <div
+            className={`flex flex-wrap gap-x-3 gap-y-1 text-sm mb-8 pb-6 border-b ${
+              theme === 'dark'
+                ? 'text-surface-400 border-surface-800'
+                : theme === 'sepia'
+                  ? 'text-[#7a6a55] border-[#d6ccb4]'
+                  : 'text-surface-500 border-surface-200'
+            }`}
+          >
+            {author && <span>{author}</span>}
+            {readingTime && <span>{readingTime} min read</span>}
+            {wordCount > 0 && <span>{wordCount.toLocaleString()} words</span>}
+          </div>
+
+          {/* Paragraphs */}
+          {paragraphs.length > 0 ? (
+            <div className="space-y-4 leading-relaxed">
+              {paragraphs.map((para, i) => (
+                <p key={i}>
+                  {para.split('\n').map((line, j, arr) => (
+                    <span key={j}>
+                      {line}
+                      {j < arr.length - 1 && <br />}
+                    </span>
+                  ))}
+                </p>
+              ))}
+            </div>
+          ) : (
+            <p
+              className={`text-center py-12 ${theme === 'dark' ? 'text-surface-500' : 'text-surface-400'}`}
+            >
+              No extracted content available.
+            </p>
+          )}
+
+          {/* Bottom padding for footer */}
+          <div className="h-16" />
+        </div>
+      </div>
+
+      {/* Footer */}
+      <footer
+        className={`flex items-center justify-between px-4 py-2 border-t ${headerThemeClasses} shrink-0`}
+      >
+        <span
+          className={`text-xs ${theme === 'dark' ? 'text-surface-500' : theme === 'sepia' ? 'text-[#7a6a55]' : 'text-surface-400'}`}
+        >
+          {minutesRemaining !== null && minutesRemaining > 0
+            ? `${minutesRemaining} min remaining`
+            : wordCount > 0
+              ? 'Finished'
+              : ''}
+        </span>
+
+        {bookmark.status !== 'done' ? (
+          <button
+            onClick={() => onCycleStatus(bookmark.id, statusNext)}
+            className="px-3 py-1.5 rounded-lg bg-primary-600 text-white text-xs font-medium hover:bg-primary-700 min-h-[36px] transition-colors"
+          >
+            {bookmark.status === 'unread' ? 'Start Reading' : 'Mark Done'}
+          </button>
+        ) : (
+          <span className="text-xs font-medium text-green-600 dark:text-green-400">✓ Done</span>
+        )}
+      </footer>
+    </div>
+  );
+}

--- a/src/hooks/useReaderPrefs.ts
+++ b/src/hooks/useReaderPrefs.ts
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+
+export type FontSize = 'sm' | 'md' | 'lg';
+export type FontFamily = 'sans' | 'serif';
+export type ReaderTheme = 'light' | 'dark' | 'sepia';
+
+interface ReaderPrefs {
+  fontSize: FontSize;
+  fontFamily: FontFamily;
+  theme: ReaderTheme;
+}
+
+const DEFAULT_PREFS: ReaderPrefs = { fontSize: 'md', fontFamily: 'sans', theme: 'light' };
+const STORAGE_KEY = 'reader_prefs';
+
+export function useReaderPrefs() {
+  const [prefs, setPrefs] = useState<ReaderPrefs>(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      return saved
+        ? { ...DEFAULT_PREFS, ...(JSON.parse(saved) as Partial<ReaderPrefs>) }
+        : DEFAULT_PREFS;
+    } catch {
+      return DEFAULT_PREFS;
+    }
+  });
+
+  function update(updates: Partial<ReaderPrefs>) {
+    setPrefs((prev) => {
+      const next = { ...prev, ...updates };
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      } catch {
+        /* storage unavailable */
+      }
+      return next;
+    });
+  }
+
+  return { ...prefs, update };
+}

--- a/src/lib/demo-data.ts
+++ b/src/lib/demo-data.ts
@@ -7,13 +7,85 @@ function daysAgo(n: number): string {
 }
 
 const SAMPLE_CONTENT: BookmarkContent = {
-  text: 'A well-structured monolith is easier to split into services later than a poorly structured microservice architecture. The key insight is that module boundaries within a monolith can be just as strong as service boundaries...',
+  text: `A well-structured monolith is easier to split into services later than a poorly structured microservice architecture. The key insight is that module boundaries within a monolith can be just as strong as service boundaries — the difference is that they're enforced by code conventions rather than network boundaries.
+
+The argument for microservices has always been about organizational scaling: Conway's Law tells us that software architecture mirrors the communication structure of the teams building it. But for most teams, a modular monolith provides 80% of the benefits with 20% of the operational overhead.
+
+What makes a modular monolith successful is strict adherence to module boundaries in code. Each module owns its data — no module reaches into another module's database tables. Cross-module communication goes through defined interfaces, not direct function calls into implementation details.
+
+The failure mode of the monolith is not the monolith itself, but the big ball of mud: an unmodularized codebase where everything depends on everything else. This is what gives monoliths a bad reputation, and what makes them hard to split later.
+
+The failure mode of microservices is distributed systems complexity introduced before you actually need it: network failures, eventual consistency, distributed transactions, service discovery, and the cascade of operational concerns that come with running dozens of independent services.
+
+The pragmatic path: start with a well-modularized monolith. Define clear module boundaries from day one. When — and only when — a specific module needs to scale independently or be owned by a separate team, extract it into a service. The boundaries you defined in the monolith become your service contracts.
+
+This approach also means your deployment story stays simple early in a project's life, when you have the least certainty about the right boundaries. It's much easier to refine module boundaries within a codebase than to change service contracts across independently deployed systems.
+
+Teams that succeed with this approach treat the module boundary as seriously as a service boundary: no shared mutable state, explicit interfaces, separate test suites per module, and module-scoped database schemas (even if they share a single database instance).
+
+The key metrics to watch: if a single module accounts for more than 30% of your deployment risk, or if a module's team has grown to the point where they're stepping on each other's work, those are signals it's time to extract. Not the size of the codebase alone.`,
   author: 'Martin Fowler',
   word_count: 5100,
   reading_time: 20,
   excerpt:
     'Finding the sweet spot between monolith and microservices — a practical guide to modular architecture.',
   extracted_at: daysAgo(2),
+  method: 'readability',
+};
+
+const DEMO_CONTENT_USEEFFECT: BookmarkContent = {
+  text: `useEffect is one of the most misunderstood hooks in React. Many developers reach for it as a catch-all for "I need to do something after render" — but that framing leads to bugs, infinite loops, and code that's hard to reason about.
+
+The mental model that actually works: useEffect lets you synchronize your component with something outside React. That "something" might be a browser API, a network request, a subscription, or a third-party library. If you're not synchronizing with something external, you probably don't need useEffect.
+
+The cleanup function is not optional. Every effect that sets up a subscription, starts an interval, or registers an event listener must return a cleanup function. React runs cleanup before re-running the effect and when the component unmounts. Forgetting this is the number one source of memory leaks and stale closure bugs.
+
+The dependency array is a contract, not a performance optimization. Every value from the component scope that the effect reads must be in the dependency array. If you find yourself adding a comment like "// eslint-disable-next-line" to suppress the exhaustive-deps warning, that's a signal your effect design needs rethinking, not that the linter is wrong.
+
+Common patterns and their correct implementations:
+
+Data fetching: The most common misuse. Modern React recommends using a data-fetching library like TanStack Query or SWR instead of raw useEffect for fetching. These handle caching, deduplication, loading states, and error states correctly. If you must use useEffect for fetching, always handle the cleanup with an AbortController to cancel in-flight requests when the component unmounts.
+
+Event listeners: Add the listener in the effect, remove it in the cleanup. Pass the handler as a ref if it needs to close over component state to avoid stale closures.
+
+Timers: Create the timer in the effect, clear it in the cleanup. Don't use the timer ID from a ref — let the closure capture it.
+
+Derived state: Never use useEffect to compute derived state from props or other state. Compute it directly during render, or use useMemo for expensive computations.
+
+The rules of hooks exist because React relies on call order stability. Effects are no different — the same number of hook calls, in the same order, every render. Conditional effects are achieved by putting the condition inside the effect, not by conditionally calling useEffect.`,
+  author: 'Dan Abramov',
+  word_count: 8900,
+  reading_time: 35,
+  excerpt:
+    'A deep dive into the mental model, dependency arrays, cleanup functions, and common pitfalls of useEffect.',
+  extracted_at: daysAgo(5),
+  method: 'readability',
+};
+
+const DEMO_CONTENT_BROWSER_DESIGN: BookmarkContent = {
+  text: `Designing directly in the browser sounds counterintuitive if you've spent years in Figma or Sketch. But for components that live in the browser, the browser is the right design tool.
+
+The problem with mockup tools is fidelity loss: you design something that looks pixel-perfect in Figma, then implement it in CSS, and it never quite matches. Text rendering is different. Spacing is different. The way fonts scale at different viewport sizes is different. You spend hours reconciling the mockup with the implementation.
+
+Designing in the browser eliminates that gap entirely. What you see during design is what ships.
+
+The workflow: start with semantic HTML. A heading, some paragraphs, a list. No classes, no styling — just the structure. Then add CSS incrementally, making decisions in the browser where the feedback loop is immediate. Use browser DevTools as your design canvas; toggle properties, try different values, copy the winning CSS back to your editor.
+
+Responsive design becomes natural this way. You can drag the browser window to see how your component behaves at different widths, immediately. In Figma, responsive behavior is a separate artboard. In the browser, it's always there.
+
+The objection is usually about iteration speed: isn't it faster to prototype in Figma? For visual explorations with stakeholders who can't read code, yes. But for a developer designing their own components, the context switch between Figma and the codebase has a cost. Designing in the browser means staying in one context.
+
+Typography decisions reveal themselves differently in the browser. You immediately see how the font renders at the system level — anti-aliasing, subpixel rendering, the way different weights look at small sizes. These details are invisible in mockup tools.
+
+The practical setup: a hot-reloading dev server (Vite is ideal), a minimal component scaffolded with HTML, and a browser window side-by-side with your editor. No extensions required, no special tooling. Just the fundamentals working together.
+
+Start small: try designing your next button component this way. Or a card. The technique scales from atoms to full page layouts, but the best place to start is with something you can complete in an afternoon.`,
+  author: 'Jim Nielsen',
+  word_count: 1800,
+  reading_time: 7,
+  excerpt:
+    'Skip the mockup tools — designing directly in CSS gives you real typography, real spacing, and real interactions.',
+  extracted_at: daysAgo(1),
   method: 'readability',
 };
 
@@ -235,9 +307,9 @@ export const DEMO_BOOKMARKS: Bookmark[] = [
     tags: ['design', 'css'],
     areas: [],
     metadata: { word_count: 1800, reading_time: 7 },
-    content: {},
-    content_status: 'pending',
-    content_fetched_at: null,
+    content: DEMO_CONTENT_BROWSER_DESIGN,
+    content_status: 'success',
+    content_fetched_at: daysAgo(1),
     synced: false,
     created_at: daysAgo(3),
     status_changed_at: daysAgo(3),
@@ -330,9 +402,9 @@ export const DEMO_BOOKMARKS: Bookmark[] = [
     tags: ['react', 'frontend'],
     areas: [],
     metadata: { word_count: 8900, reading_time: 35 },
-    content: {},
-    content_status: 'pending',
-    content_fetched_at: null,
+    content: DEMO_CONTENT_USEEFFECT,
+    content_status: 'success',
+    content_fetched_at: daysAgo(5),
     synced: true,
     created_at: daysAgo(13),
     status_changed_at: daysAgo(9),


### PR DESCRIPTION
## Summary

- Adds a full-screen **ReaderModal** triggered from the DetailPanel when extracted content is available (`content_status === 'success'`). Works on both mobile and desktop.
- Typography controls: font size (S/M/L), font family (sans/serif), theme (light/dark/sepia) — all persisted to `localStorage` via `useReaderPrefs` hook.
- Reading progress bar (scroll-based), minutes-remaining estimate (238 WPM), and status action button (Start Reading / Mark Done / ✓ Done).
- 3 demo bookmarks now have realistic extracted content for in-demo testing.

## Test plan

- [ ] Open demo mode → click any blog bookmark with "success" content status (demo-9, demo-10, demo-13) → "Read" button appears in detail panel
- [ ] Clicking "Read" opens full-screen reader with title, author, reading time, and paragraphs
- [ ] Progress bar fills as you scroll; "X min remaining" updates
- [ ] Font size, font family, and theme controls work; reopen reader confirms prefs persisted
- [ ] ESC key closes reader; X button closes reader
- [ ] "Mark Done" / "Start Reading" button calls status cycle
- [ ] Bookmarks without extracted content (content_status !== 'success') show no Read button
- [ ] All 119 tests pass: `npm run test`
- [ ] Quality pipeline passes: format:check → lint → typecheck → test → build

Closes #6