### PR TITLE
fix: improve reader mode content formatting and typography

### DIFF
--- a/src/lib/__tests__/reader.test.ts
+++ b/src/lib/__tests__/reader.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { parseContentBlocks } from '../reader';
+
+describe('parseContentBlocks', () => {
+  it('returns empty array for empty string', () => {
+    expect(parseContentBlocks('')).toEqual([]);
+    expect(parseContentBlocks('   ')).toEqual([]);
+  });
+
+  it('parses single paragraph', () => {
+    const result = parseContentBlocks('This is a paragraph of text that goes on for a while.');
+    expect(result).toEqual([
+      { type: 'paragraph', text: 'This is a paragraph of text that goes on for a while.' },
+    ]);
+  });
+
+  it('splits double-newline text into multiple paragraphs', () => {
+    const result = parseContentBlocks('First paragraph.\n\nSecond paragraph.');
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ type: 'paragraph', text: 'First paragraph.' });
+    expect(result[1]).toEqual({ type: 'paragraph', text: 'Second paragraph.' });
+  });
+
+  it('falls back to single-newline splitting when no double newlines exist', () => {
+    const result = parseContentBlocks('First paragraph.\nSecond paragraph.\nThird paragraph.');
+    expect(result).toHaveLength(3);
+    expect(result.every((b) => b.type === 'paragraph')).toBe(true);
+  });
+
+  it('detects a short colon-ending line as a heading', () => {
+    const result = parseContentBlocks('Overview:\n\nThis is the overview paragraph.');
+    const heading = result.find((b) => b.type === 'heading');
+    expect(heading).toEqual({ type: 'heading', text: 'Overview:' });
+  });
+
+  it('detects a short non-sentence line as a heading', () => {
+    const result = parseContentBlocks('Getting Started\n\nHere is the body text for this section.');
+    const heading = result.find((b) => b.type === 'heading');
+    expect(heading).toEqual({ type: 'heading', text: 'Getting Started' });
+  });
+
+  it('does not classify a sentence ending with period as a heading', () => {
+    const result = parseContentBlocks('This is a short sentence.');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.type).toBe('paragraph');
+  });
+
+  it('does not classify a long line as a heading even without punctuation', () => {
+    const longLine =
+      'This is a very long line that exceeds the heading character limit and should be a paragraph not a heading';
+    const result = parseContentBlocks(longLine);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.type).toBe('paragraph');
+  });
+
+  it('detects hyphen bullet list', () => {
+    const text = '- First item\n- Second item\n- Third item';
+    const result = parseContentBlocks(text);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      type: 'list',
+      items: ['First item', 'Second item', 'Third item'],
+    });
+  });
+
+  it('detects numbered list', () => {
+    const text = '1. First step\n2. Second step\n3. Third step';
+    const result = parseContentBlocks(text);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      type: 'list',
+      items: ['First step', 'Second step', 'Third step'],
+    });
+  });
+
+  it('detects bullet list with • character', () => {
+    const text = '• Item one\n• Item two\n• Item three';
+    const result = parseContentBlocks(text);
+    const block = result.find((b) => b.type === 'list');
+    expect(block).toBeDefined();
+    if (block?.type === 'list') {
+      expect(block.items).toHaveLength(3);
+    }
+  });
+
+  it('does not classify a single list line as a list', () => {
+    const result = parseContentBlocks('- Only one item');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.type).toBe('paragraph');
+  });
+
+  it('handles mixed content: heading + paragraph + list', () => {
+    const text = [
+      'Key Patterns:',
+      '',
+      'Here is the paragraph explaining the patterns.',
+      '',
+      '- Pattern one',
+      '- Pattern two',
+      '- Pattern three',
+    ].join('\n');
+    const result = parseContentBlocks(text);
+    expect(result).toHaveLength(3);
+    expect(result[0]!.type).toBe('heading');
+    expect(result[1]!.type).toBe('paragraph');
+    expect(result[2]!.type).toBe('list');
+  });
+
+  it('strips list markers from list items', () => {
+    const text = '- Alpha\n- Beta\n- Gamma';
+    const result = parseContentBlocks(text);
+    const block = result.find((b) => b.type === 'list');
+    if (block?.type === 'list') {
+      expect(block.items).toEqual(['Alpha', 'Beta', 'Gamma']);
+    }
+  });
+});

--- a/src/lib/reader.ts
+++ b/src/lib/reader.ts
@@ -1,0 +1,109 @@
+/**
+ * Parses plain text extracted by Readability into structured content blocks.
+ * Detects headings, bullet/numbered lists, and paragraphs from formatting heuristics.
+ */
+
+export type ContentBlock =
+  | { type: 'heading'; text: string }
+  | { type: 'paragraph'; text: string }
+  | { type: 'list'; items: string[] };
+
+/** Matches lines that start with a bullet or numbered list marker */
+const LIST_MARKER = /^([-•*]|\d+[.):])\s+\S/;
+
+/**
+ * A single short line is treated as a heading if:
+ * - 3–90 characters
+ * - No more than 10 words
+ * - Doesn't end with a sentence-terminating character (. , ; !)
+ *   Exception: lines ending with ':' are strong heading candidates
+ * - Not a list item itself
+ */
+function looksLikeHeading(line: string): boolean {
+  if (line.length < 3 || line.length > 90) return false;
+  if (LIST_MARKER.test(line)) return false;
+  const wordCount = line.split(/\s+/).length;
+  if (wordCount > 10) return false;
+  // Lines ending with ':' are section intros — strong heading signal
+  if (line.endsWith(':')) return true;
+  // Reject lines that end like regular sentences
+  if (/[.,;!]$/.test(line)) return false;
+  return true;
+}
+
+/**
+ * Split raw extracted text into chunks separated by paragraph breaks.
+ * Handles both double-newline (\n\n) and single-newline (\n) separators,
+ * since Readability output varies by site.
+ */
+function splitIntoChunks(text: string): string[] {
+  // Prefer double-newline splitting; fall back to single-newline if text
+  // has very few double-newlines (e.g. content from sites using \n only)
+  const doubleNewlineChunks = text
+    .split(/\n{2,}/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (doubleNewlineChunks.length >= 3) return doubleNewlineChunks;
+
+  // Fallback: split on single newlines
+  return text
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * After single-newline fallback splitting produces individual lines,
+ * merge consecutive list-marker lines back into one chunk so the list
+ * detector sees them as a group rather than isolated single-item chunks.
+ */
+function mergeAdjacentListItems(chunks: string[]): string[] {
+  const result: string[] = [];
+  for (const chunk of chunks) {
+    // Pop the last element (returns undefined if empty — no length guard needed)
+    const prev = result.pop();
+    if (prev !== undefined && LIST_MARKER.test(prev) && LIST_MARKER.test(chunk)) {
+      // Both current and previous are list items — combine into one multi-line chunk
+      result.push(prev + '\n' + chunk);
+    } else {
+      if (prev !== undefined) result.push(prev);
+      result.push(chunk);
+    }
+  }
+  return result;
+}
+
+export function parseContentBlocks(text: string): ContentBlock[] {
+  if (!text.trim()) return [];
+
+  const chunks = mergeAdjacentListItems(splitIntoChunks(text));
+  const blocks: ContentBlock[] = [];
+
+  for (const chunk of chunks) {
+    const lines = chunk
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+    if (lines.length === 0) continue;
+
+    // Single-line chunk that looks like a heading
+    const firstLine = lines[0];
+    if (lines.length === 1 && firstLine !== undefined && looksLikeHeading(firstLine)) {
+      blocks.push({ type: 'heading', text: firstLine });
+      continue;
+    }
+
+    // Chunk where the majority of lines are list items
+    const listLines = lines.filter((l) => LIST_MARKER.test(l));
+    if (listLines.length >= 2 && listLines.length / lines.length >= 0.5) {
+      const items = listLines.map((l) => l.replace(/^([-•*]|\d+[.):]) /, '').trim());
+      blocks.push({ type: 'list', items });
+      continue;
+    }
+
+    // Default: paragraph
+    blocks.push({ type: 'paragraph', text: chunk });
+  }
+
+  return blocks;
+}


### PR DESCRIPTION
## Summary

- Adds `parseContentBlocks()` in `src/lib/reader.ts` — detects **headings** (short lines ending with `:` or lacking sentence punctuation), **bullet/numbered lists** (≥ 2 items), and **paragraphs** from raw Readability plain text. Also handles sites that use `\n` instead of `\n\n` for paragraph breaks.
- Reader renders structured blocks: `<h2>` headings with generous top spacing, `<ul>/<li>` for lists, `<p>` with `leading-[1.8]` line height.
- Narrows content column from `max-w-2xl` (672px) to `max-w-prose` (65ch) — the research-backed optimal line length for comfortable reading.
- Fixes a bug where all three font size buttons showed `'A'` identically — they're now visually distinct (xs/sm/base).

## Test plan

- [ ] Open reader on a demo bookmark (demo-9, demo-10, demo-13) and verify sections are separated clearly
- [ ] Section intro lines (ending with `:`) render as `<h2>` with bold styling and extra top spacing
- [ ] Bullet lists render with disc markers, not as flat text
- [ ] Content feels narrower and more comfortable to read than before
- [ ] Font size buttons are visually different (small A / medium A / large A)
- [ ] All 133 tests pass: `npx vitest run`
- [ ] Quality pipeline: format:check → lint → typecheck → test → build all pass

Closes (improvement of) #6