### PR TITLE
fix: metadata race conditions, filter independence, PWA back button

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -46,7 +46,8 @@ docs/
 │   ├── v3.0-areas-tagging-redesign.md # Areas & tagging two-tier model
 │   ├── v3.0-full-text-search.md    # 1.3 Full-text search
 │   ├── v3.0-reader-mode.md         # 1.5 Reader mode
-│   └── v3.0-testing-ci.md         # 1.6 Testing & CI (Vitest + GitHub Actions)
+│   ├── v3.0-testing-ci.md         # 1.6 Testing & CI (Vitest + GitHub Actions)
+│   └── v3.0-bug-fixes-session1.md # Session 1: metadata races, filter independence, PWA back button
 ├── guides/                         # How-to references
 │   ├── workflow.md                 # Development practices, session workflow
 │   └── supabase-auth-setup.md      # Supabase Auth provider configuration
@@ -61,6 +62,7 @@ docs/
 
 | Version | Feature | Log |
 |---|---|---|
+| v3.0 | Bug fixes: metadata races, filter independence, PWA back button (8 bugs, 139 tests) | [log/v3.0-bug-fixes-session1.md](log/v3.0-bug-fixes-session1.md) |
 | v3.0 | Reader mode (full-screen, typography controls, progress, sepia theme) | [log/v3.0-reader-mode.md](log/v3.0-reader-mode.md) |
 | v3.0 | Full-text search (excerpt + content.text, debounce, result count, tsvector) | [log/v3.0-full-text-search.md](log/v3.0-full-text-search.md) |
 | v3.0 | Testing & CI (Vitest 95 tests, GitHub Actions pipeline) | [log/v3.0-testing-ci.md](log/v3.0-testing-ci.md) |

--- a/docs/log/v3.0-bug-fixes-session1.md
+++ b/docs/log/v3.0-bug-fixes-session1.md
@@ -1,0 +1,71 @@
+# Session 1 Bug Fixes — Metadata Race Conditions, Filter Independence, PWA Back Button
+
+**Issue:** #16 | **Branch:** `fix/16-metadata-race-filter-bugs` | **Date:** 2026-02-24
+
+## What Was Fixed
+
+### 1. Metadata race condition A — Substack / blog (P0)
+**Root cause:** `triggerExtraction` and `autoFetchMetadataAndTag` both fired as `void` in parallel from `addBookmark.onSuccess`. The edge function completed and called `queryClient.invalidateQueries`, triggering a full DB refetch before `autoFetchMetadataAndTag` had finished writing metadata to DB. The refetch returned stale data, clobbering the cache. Manual refresh worked because it retried at a quiet time.
+
+**Fix:** Changed `onSuccess` to chain: `autoFetchMetadataAndTag(newBookmark).then(() => triggerExtraction(newBookmark))`. Extraction now runs only after metadata is confirmed written.
+
+### 2. Metadata race condition B — startup batch enrichment (P1)
+**Root cause:** `Dashboard.tsx` batch enrichment used `void db.from('bookmarks').update(...)` inside a `Promise.allSettled` callback. The outer promise resolved when `fetchMetadata` calls finished, but the DB writes were still in flight. `invalidateQueries` then fired before writes completed, returning stale data.
+
+**Fix:** Changed `void db.from(...)` to `await db.from(...)` so all writes complete before `invalidateQueries`.
+
+### 3. YouTube channel/duration not loading (P0 extension)
+**Root cause:** The startup batch filtered `b => !b.title`. YouTube bookmarks with a title (set by oEmbed) but no `metadata.channel` or `duration` were permanently skipped and never re-enriched.
+
+**Fix:** Widened batch filter: `!b.title || (b.source_type === 'youtube' && !b.metadata?.channel)`.
+
+### 4. Areas flash and disappear after saving with areas selected (P1)
+**Root cause:** `autoFetchMetadataAndTag` updated the cache using `{ ...newBookmark, ...updates }` where `newBookmark` came from the plain `.insert().select()` (no `bookmark_tags` join, so `areas: []`). This spread clobbered areas that `setBookmarkAreas` had already written to the cache.
+
+**Fix:** Cache update now merges into the current live cache entry: `old?.map((b) => b.id === bookmark.id ? { ...b, ...updates } : b)`. The enriched bookmark for AI tagging is then read back from the live cache.
+
+### 5. Twitter title includes t.co URL (P1)
+**Root cause:** Twitter always appends a `t.co` tracking URL to tweet HTML for any tweet containing media or links. Our extraction stripped HTML tags but not URL text.
+
+**Fix:** Added `.replace(/https?:\/\/t\.co\/\S+/g, '')` to the tweet text pipeline in `fetchTwitterMetadata`.
+
+### 6. Uncategorized count mismatch (P1)
+**Root cause:** `AreasView.tsx` counted uncategorized as `b.areas.length === 0`. `BookmarkList.tsx` filtered `__untagged__` as `b.areas.length === 0 AND b.tags.length === 0`. Different definitions caused the count shown on the card to differ from what appeared after clicking through.
+
+**Fix:** Changed `BookmarkList` `__untagged__` filter to `b.areas.length === 0` only. Tags are a separate dimension from areas.
+
+### 7. PWA back button closes app instead of reader (P1)
+**Root cause:** `ReaderModal` opened as a React modal with no browser history entry. Android/iOS back gesture triggered `popstate` which navigated away from the SPA.
+
+**Fix:** Added `history.pushState({ reader: true }, '')` when the reader opens. Added a `popstate` event listener that calls `onClose()` instead of letting the browser navigate.
+
+### 8. Favorites × Area filter can't combine; status tabs clear area (P1)
+**Root cause:** Sidebar and MobileNav nav click handlers aggressively cleared each other's filter state:
+- Favorites click: `setFavorites(true); setStatus('all'); setTag(null)` — cleared area
+- Status tabs: `setStatus(x); setTag(null); setFavorites(false)` — cleared area and favorites
+- MobileNav status tabs: `setStatus(x); setFavorites(false)` — cleared favorites
+
+**Fix:** Each nav action now only changes its own dimension. Favorites is now a toggle (`setFavorites(!showFavorites)`). Status tabs only call `setStatus(status)`. `active` states simplified to reflect their own dimension only (removed `!currentTag && !showFavorites` conditions from status tab active checks).
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/hooks/useBookmarks.ts` | Race A fix: sequence metadata→extraction; areas-flash fix: merge into live cache |
+| `src/pages/Dashboard.tsx` | Race B fix: `await` DB writes; widen batch filter for YouTube |
+| `src/lib/metadata.ts` | Strip `t.co` URLs from tweet text |
+| `src/components/feed/BookmarkList.tsx` | `__untagged__` filter: areas-only |
+| `src/components/reader/ReaderModal.tsx` | PWA back button: `pushState` + `popstate` handler |
+| `src/components/layout/Sidebar.tsx` | Filter independence: remove cross-clearing from nav actions |
+| `src/components/layout/MobileNav.tsx` | Filter independence: remove cross-clearing from nav actions |
+| `src/components/__tests__/BookmarkList.test.tsx` | New tests: uncategorized filter, filter independence |
+| `src/lib/__tests__/metadata.test.ts` | New tests: t.co URL stripping |
+| `public/sw.js` | SW cache bump: v3.0.5 → v3.0.6 |
+
+## Test Count
+139 tests passing (was 133 — added 6 new tests).
+
+## Key Decisions
+- **Sequence not parallel for metadata+extraction**: adds ~1-2s to the save flow (Microlink latency) but eliminates the entire race class. Acceptable trade-off since the race caused silent data loss.
+- **Favorites as toggle**: more intuitive than "click Favorites = go to Favorites mode". Now it's a filter layer you can switch on/off at any time without disrupting other filters.
+- **`__untagged__` = no areas only**: in the areas context, "uncategorized" means "not assigned to any area". Tags are orthogonal. Changing this makes the count-to-list flow consistent.

--- a/docs/user-feedback.md
+++ b/docs/user-feedback.md
@@ -1,0 +1,193 @@
+# User Feedback Scratchpad
+
+> Drop all feedback here — bugs, UX complaints, feature requests, anything.
+> At the start of a session, share this file and we'll triage together.
+
+---
+
+## Pending (unreviewed)
+
+<!-- Paste new feedback here -->
+
+---
+
+## Triaged
+
+### [BUG P0] Metadata / title not loading on save — two distinct race conditions
+**Reported:** 24 Feb | **Status:** Confirmed, root causes identified (deep dive)
+
+**Race Condition A — Substack / blog (triggerExtraction clobbers metadata):**
+- `triggerExtraction` and `autoFetchMetadataAndTag` both fire as `void` in parallel from `addBookmark.onSuccess`
+- Edge function completes → `queryClient.invalidateQueries` fires → full DB refetch while Microlink is still fetching
+- Refetch lands before `autoFetchMetadataAndTag` writes to DB → stale snapshot overwrites cache
+- Metadata WAS written to DB — manual refresh re-reads the correct DB state
+
+**Race Condition B — Startup batch enrichment (Dashboard.tsx:129):**
+- The `enrichAndTag` effect runs on load for all bookmarks with `!b.title`
+- DB writes inside the batch are `void` (fire and forget inside `Promise.allSettled`)
+- `invalidateQueries` at line 143 fires immediately after `fetchMetadata` calls resolve — BEFORE DB writes complete
+- Fix: `await db.from('bookmarks').update(...)` inside the batch, not `void`
+
+**YouTube (channel/duration) specific:**
+- Extraction is skipped for YouTube so Race A doesn't apply
+- Most likely cause: `autoFetchMetadataAndTag` succeeds but the cache update uses `enriched = { ...newBookmark, ...updates }` where `newBookmark` came from the plain `.insert().select()` (no junction table join → `areas: []`)
+- If `setBookmarkAreas` had already put areas in cache, this overwrites them, causing a visible flicker
+- Additionally: if the DB write inside `autoFetchMetadataAndTag` fails silently (network jitter, auth expiry), `if (!error)` blocks the cache update too — so channel/duration never appear until manual refresh retries successfully
+- The startup `enrichAndTag` batch only re-fetches for `!b.title` — YouTube bookmarks with a title but no channel/duration are permanently orphaned unless manually refreshed
+
+### [BUG P1] Areas flash and disappear after adding a bookmark with areas assigned
+**Reported:** 24 Feb (found during deep dive) | **Status:** Confirmed
+- In `addBookmark.onSuccess` (useBookmarks.ts): sets cache with `newBookmark` (areas: []), fires `void autoFetchMetadataAndTag(newBookmark)`
+- Dashboard.tsx callback fires `void setBookmarkAreas(...)` which updates cache with correct areas
+- `autoFetchMetadataAndTag` completes ~1-2s later: updates cache using `{ ...newBookmark, ...updates }` — `newBookmark.areas = []` — OVERWRITES the areas set by `setBookmarkAreas`
+- Areas then come back only after `triggerExtraction`'s `invalidateQueries` or manual page action
+- Fix: in `autoFetchMetadataAndTag`, merge areas from current cache state, not from the stale `newBookmark`
+
+### [BUG P1] Twitter title includes embedded t.co URL
+**Reported:** 24 Feb | **Status:** Confirmed
+- Twitter always appends a t.co link to tweet HTML (for any media or link in the tweet)
+- Our regex strips HTML tags but not URL text — so title becomes `"Author: Great article https://t.co/xyz123"`
+- Fix: strip `https?://\S+` URL patterns from extracted tweet text before building the title
+
+### [BUG P1] Uncategorized count mismatches what appears in list
+**Reported:** 24 Feb | **Status:** Confirmed, logic inconsistency
+- `AreasView.tsx:28` counts uncategorized as `b.areas.length === 0` (no areas, may have tags)
+- `BookmarkList.tsx:59-61` `__untagged__` filter requires `b.areas.length === 0 AND b.tags.length === 0`
+- Fix: align to `b.areas.length === 0` only — "uncategorized" in the Areas view means unassigned to an area; tags are a separate dimension
+
+### [BUG P1] Back button in PWA closes the app instead of closing Reader
+**Reported:** 24 Feb | **Status:** Confirmed
+- ReaderModal opens with no browser history entry — Android/iOS back gesture = `popstate` = browser navigation away from SPA
+- Also affects: any full-screen modal (Add, Edit, Settings) in PWA context
+- Fix: `history.pushState({modal: 'reader'}, '')` on open; `popstate` listener in ReaderModal calls `onClose()` and `e.preventDefault()`
+
+### [BUG P1] Favorites × Area filter can't be combined; status tabs clear area too
+**Reported:** 24 Feb | **Status:** Confirmed — filter logic is correct, nav actions are wrong
+- `BookmarkList.tsx` filter pipeline correctly stacks all dimensions independently ✓
+- Bug is in navigation actions:
+  - Sidebar Favorites: `setFavorites(true); setStatus('all'); setTag(null)` → clears area
+  - Sidebar status tabs: `setStatus(x); setTag(null); setFavorites(false)` → clears area AND favorites
+  - MobileNav status tabs: `setStatus(x); setFavorites(false)` → clears favorites
+- Design principle (confirmed by user): each filter dimension (status / source / area / favorites) is independent; changing one must not reset others
+- Fix: remove cross-clearing from all nav actions. Each setter only changes its own dimension.
+
+---
+
+### Deep Dive: Associated Bug Families
+
+#### Family 1 — Race conditions from over-use of `invalidateQueries`
+All three locations that fire `invalidateQueries` can race with concurrent async writes:
+1. `triggerExtraction` → after edge function completes [confirmed P0]
+2. Dashboard.tsx `enrichAndTag` batch → after fetchMetadata resolves but before `void` DB writes complete [confirmed P1]
+3. Dashboard.tsx AI tagging loop → `invalidateQueries` at line 168 after tagging loop, same risk
+
+**Fix pattern**: Replace full `invalidateQueries` with targeted cache merges. Only use `invalidateQueries` when you know all DB writes have settled.
+
+#### Family 2 — Silent failure (catch {} swallows everything)
+No errors are surfaced to the developer or user for:
+- `autoFetchMetadataAndTag` — metadata fetch + DB write errors
+- `triggerExtraction` — edge function errors
+- `autoSuggestTags` — AI tagging errors
+- Per-bookmark errors in `enrichAndTag` batch
+This makes debugging production failures impossible. The Microlink 50 req/day rate limit, YouTube API quota, OpenRouter rate limits — all silently fail.
+**Fix**: At minimum, `console.warn` on failures during development. Consider showing a subtle persistent badge when enrichment fails.
+
+#### Family 3 — Cache updates using stale insert data (no junction join)
+`addBookmark.mutationFn` uses `.insert().select()` without the `bookmark_tags(...)` join. The returned `newBookmark` has `areas: []`. Any subsequent cache update using `{ ...newBookmark, ... }` clobbers areas populated by `setBookmarkAreas`. This is the root of the areas-flash bug and could affect any other feature that does similar spread-merge.
+**Fix**: In `autoFetchMetadataAndTag` and any post-add enrichment, read `areas` from the current cache state, not from `newBookmark`.
+
+#### Family 4 — Startup batch ignores partially enriched bookmarks
+`enrichAndTag` filters: `bookmarks.filter((b) => !b.title)`. Bookmarks with a title but no `metadata.channel`, `metadata.duration`, or `image` are never re-enriched by the startup pass. These sit "half-enriched" permanently — only fixable by manually pressing refresh on each one.
+**Fix**: Widen the startup filter to catch bookmarks missing key fields per their source type (e.g., YouTube with no `metadata.channel`).
+
+#### Family 5 — OpenRouter rate limiting / AI tag quality
+Free model rate limits on OpenRouter hit silently. The AI tagging fires for every new bookmark. No debounce, no backoff, no queue. Under normal usage this is fine, but bursts (adding 5+ bookmarks quickly) will hit limits.
+**Fix** (lower priority): Queue AI tagging requests with a small delay between them.
+
+---
+
+### [FEATURE P1] Book capture without a URL
+**Reported:** 24 Feb | **Status:** Planned
+- `book` source type exists but URL is required in the add modal — books tab is effectively unused
+- Desired: Log any book immediately (from recommendation, article, conversation)
+  - URL optional (Goodreads/Amazon link if available, but not required)
+  - Author field (book-specific metadata)
+  - Status: Want to Read (unread) / Reading (reading) / Finished (done) — maps naturally to existing status
+  - Notes + Obsidian export already work — no changes needed
+- NOT in scope now: Apple Books API sync, in-app reading
+- Fix direction: Make URL optional when source_type = 'book' in AddBookmarkModal; add author field
+
+### [FEATURE P2] Obsidian export: tags as wikilinks
+**Reported:** 24 Feb | **Status:** Planned
+- Currently exports `tags: ["tag1", "tag2"]` in YAML frontmatter
+- Desired: `[[tag1]]` wikilink format for Obsidian backlink graph integration
+- Fix direction: Add toggle in export options OR always use `[[tag]]` in YAML
+
+### [FEATURE P2] GitHub repository source type
+**Reported:** 24 Feb | **Status:** Planned
+- Detect `github.com/*/*` URLs, fetch repo metadata via GitHub public API (no key needed)
+- Metadata: repo name, description, stars, language, topics
+
+### [FEATURE P2] arXiv paper source type
+**Reported:** 24 Feb | **Status:** Planned
+- Detect `arxiv.org/abs/` and `arxiv.org/pdf/` URLs
+- Fetch title, authors, abstract via arXiv API (free, no key)
+- Reader mode: show abstract + link to PDF
+
+### [FEATURE P3] YouTube transcript extraction
+**Reported:** 24 Feb | **Status:** Backlog
+
+### [FEATURE P3] Warm/Sepia theme for main app
+**Reported:** 24 Feb | **Status:** Backlog
+- Reader mode already has sepia; main app dashboard is zinc-only
+
+### [QUALITY P1] Fix tests to catch race conditions and metadata failures
+**Reported:** 24 Feb | **Status:** Planned
+- Current tests mock `fetchMetadata` entirely — race conditions and real failure modes are invisible
+- Need: test for `triggerExtraction` → `invalidateQueries` race
+- Need: test that areas are preserved after `autoFetchMetadataAndTag` completes
+- Need: test that `enrichAndTag` batch awaits DB writes before invalidating
+
+---
+
+## Session Plan
+
+### Session 1 — All bugs + quality (current)
+| # | Fix | Difficulty |
+|---|-----|------------|
+| 1 | Fix Race A: sequence `autoFetchMetadataAndTag` before `triggerExtraction` | Medium |
+| 2 | Fix Race B: `await` DB writes in `enrichAndTag` batch (Dashboard.tsx:129) | Easy |
+| 3 | Fix areas-flash: preserve cache areas in `autoFetchMetadataAndTag` update | Medium |
+| 4 | Fix startup batch: widen filter to catch bookmarks missing metadata by source type | Easy |
+| 5 | Fix Twitter: strip t.co URL from tweet text | Easy |
+| 6 | Fix uncategorized count definition | Easy |
+| 7 | Fix back button: pushState + popstate in ReaderModal | Medium |
+| 8 | Fix filter cross-clearing in Sidebar + MobileNav | Easy |
+| 9 | Quality: add tests for the above | Medium |
+
+### Session 2 — Book source type (Feature P1)
+### Session 3 — GitHub + arXiv + Obsidian wikilinks (Feature P2)
+### Session 4 — Remaining quality + test coverage
+
+---
+
+## Done / Shipped
+
+### [DONE] Metadata race conditions (PR #16 — Session 1)
+- Race A: triggerExtraction no longer races with autoFetchMetadataAndTag — sequenced
+- Race B: startup batch now awaits DB writes before invalidateQueries
+- YouTube channel/duration: startup batch widens filter to catch partially-enriched YouTube bookmarks
+- Areas flash: cache update now merges into live cache state, not stale insert data
+
+### [DONE] Twitter title includes t.co URL (PR #16 — Session 1)
+- t.co URLs stripped from tweet text before building title
+
+### [DONE] Uncategorized count mismatch (PR #16 — Session 1)
+- BookmarkList `__untagged__` filter now checks areas only (not tags)
+
+### [DONE] PWA back button closes app (PR #16 — Session 1)
+- ReaderModal pushes history entry on open; popstate listener closes reader instead of navigating away
+
+### [DONE] Favorites × Area filter can't combine (PR #16 — Session 1)
+- Sidebar and MobileNav nav actions no longer cross-clear filter dimensions
+- Favorites is now a toggle; status tabs only change status

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'contentdeck-v3.0.5'
+const CACHE_NAME = 'contentdeck-v3.0.6'
 
 self.addEventListener('install', () => {
   // Don't skip waiting — let the app decide when to activate

--- a/src/components/__tests__/BookmarkList.test.tsx
+++ b/src/components/__tests__/BookmarkList.test.tsx
@@ -202,3 +202,97 @@ describe('BookmarkList — full-text search', () => {
     expect(() => renderList(bookmarks)).not.toThrow();
   });
 });
+
+describe('BookmarkList — __untagged__ (Uncategorized) filter', () => {
+  const area = {
+    id: 'a1',
+    name: 'Tech',
+    emoji: '💻',
+    color: '#000',
+    sort_order: 0,
+    user_id: 'u1',
+    created_at: '',
+    description: null,
+  };
+
+  beforeEach(() => {
+    mockSearchQuery = '';
+    mockCurrentSource = 'all';
+    mockCurrentStatus = 'all';
+    mockCurrentSort = 'newest';
+    mockShowFavorites = false;
+    mockSelectMode = false;
+    mockSelectedIds = new Set();
+    mockCurrentTag = '__untagged__';
+  });
+
+  it('shows bookmarks with no areas (regardless of tags)', () => {
+    // A bookmark with tags but NO area — should appear in Uncategorized
+    const bookmarks = [
+      makeBookmark({ id: 'b1', title: 'Has Tags No Area', tags: ['react', 'frontend'], areas: [] }),
+      makeBookmark({ id: 'b2', title: 'Clean Slate', tags: [], areas: [] }),
+      makeBookmark({ id: 'b3', title: 'Has Area', tags: [], areas: [area] }),
+    ];
+    renderList(bookmarks);
+    expect(screen.getByText('Has Tags No Area')).toBeInTheDocument();
+    expect(screen.getByText('Clean Slate')).toBeInTheDocument();
+    expect(screen.queryByText('Has Area')).not.toBeInTheDocument();
+  });
+
+  it('hides bookmarks that have an area assigned, even with no tags', () => {
+    const bookmarks = [makeBookmark({ id: 'b1', title: 'Area No Tags', tags: [], areas: [area] })];
+    renderList(bookmarks);
+    expect(screen.queryByText('Area No Tags')).not.toBeInTheDocument();
+  });
+});
+
+describe('BookmarkList — favorites + area filter independence', () => {
+  const area = {
+    id: 'a1',
+    name: 'Tech',
+    emoji: '💻',
+    color: '#000',
+    sort_order: 0,
+    user_id: 'u1',
+    created_at: '',
+    description: null,
+  };
+
+  beforeEach(() => {
+    mockSearchQuery = '';
+    mockCurrentSource = 'all';
+    mockCurrentStatus = 'all';
+    mockCurrentSort = 'newest';
+    mockSelectMode = false;
+    mockSelectedIds = new Set();
+  });
+
+  it('shows only favorited bookmarks in the Tech area when both filters active', () => {
+    mockShowFavorites = true;
+    mockCurrentTag = 'Tech';
+    const bookmarks = [
+      makeBookmark({ id: 'b1', title: 'Fav + Tech', is_favorited: true, areas: [area] }),
+      makeBookmark({ id: 'b2', title: 'Fav no area', is_favorited: true, areas: [] }),
+      makeBookmark({ id: 'b3', title: 'Tech not fav', is_favorited: false, areas: [area] }),
+    ];
+    renderList(bookmarks);
+    expect(screen.getByText('Fav + Tech')).toBeInTheDocument();
+    expect(screen.queryByText('Fav no area')).not.toBeInTheDocument();
+    expect(screen.queryByText('Tech not fav')).not.toBeInTheDocument();
+  });
+
+  it('area filter stacks with status filter', () => {
+    mockShowFavorites = false;
+    mockCurrentTag = 'Tech';
+    mockCurrentStatus = 'unread';
+    const bookmarks = [
+      makeBookmark({ id: 'b1', title: 'Unread Tech', status: 'unread', areas: [area] }),
+      makeBookmark({ id: 'b2', title: 'Done Tech', status: 'done', areas: [area] }),
+      makeBookmark({ id: 'b3', title: 'Unread no area', status: 'unread', areas: [] }),
+    ];
+    renderList(bookmarks);
+    expect(screen.getByText('Unread Tech')).toBeInTheDocument();
+    expect(screen.queryByText('Done Tech')).not.toBeInTheDocument();
+    expect(screen.queryByText('Unread no area')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/feed/BookmarkList.tsx
+++ b/src/components/feed/BookmarkList.tsx
@@ -56,9 +56,8 @@ export default function BookmarkList({
     // Tag/Area filter
     if (currentTag) {
       if (currentTag === '__untagged__') {
-        result = result.filter(
-          (b) => (!b.tags || b.tags.length === 0) && (!b.areas || b.areas.length === 0),
-        );
+        // "Uncategorized" means not assigned to any area — tags are a separate dimension.
+        result = result.filter((b) => !b.areas || b.areas.length === 0);
       } else {
         result = result.filter(
           (b) =>

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -23,14 +23,12 @@ export default function MobileNav({ counts }: MobileNavProps) {
     >
       <div className="flex items-center">
         {tabs.map(({ status, label, icon: Icon }) => {
-          const active = currentStatus === status && !showFavorites;
+          // Active reflects only the status dimension — favorites is independent.
+          const active = currentStatus === status;
           return (
             <button
               key={status}
-              onClick={() => {
-                setStatus(status);
-                setFavorites(false);
-              }}
+              onClick={() => setStatus(status)}
               className={`flex-1 flex flex-col items-center gap-0.5 py-2 min-h-[56px] transition-colors
                 ${active ? 'text-primary-600 dark:text-primary-400' : 'text-surface-400 dark:text-surface-500'}
               `}
@@ -44,12 +42,9 @@ export default function MobileNav({ counts }: MobileNavProps) {
           );
         })}
 
-        {/* Favorites */}
+        {/* Favorites — toggles independently; does not reset status or area */}
         <button
-          onClick={() => {
-            setFavorites(true);
-            setStatus('all');
-          }}
+          onClick={() => setFavorites(!showFavorites)}
           className={`flex-1 flex flex-col items-center gap-0.5 py-2 min-h-[56px] transition-colors
             ${showFavorites ? 'text-primary-600 dark:text-primary-400' : 'text-surface-400 dark:text-surface-500'}
           `}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -65,16 +65,13 @@ export default function Sidebar({ counts, onAdd, onSignOut, onSettings, onStats 
         <div className="space-y-0.5">
           {statusNav.map(({ status, label, icon: Icon }) => {
             const count = status === 'all' ? totalCount : (counts[status] ?? 0);
-            const active = currentStatus === status && !currentTag && !showFavorites;
+            // Active reflects only the status dimension — area/favorites filters are independent.
+            const active = currentStatus === status;
             return (
               <button
                 key={status}
                 aria-current={active ? 'page' : undefined}
-                onClick={() => {
-                  setStatus(status);
-                  setTag(null);
-                  setFavorites(false);
-                }}
+                onClick={() => setStatus(status)}
                 className={`
                   w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors min-h-[44px]
                   ${
@@ -91,14 +88,10 @@ export default function Sidebar({ counts, onAdd, onSignOut, onSettings, onStats 
             );
           })}
 
-          {/* Favorites */}
+          {/* Favorites — toggles independently; does not reset status or area */}
           <button
             aria-current={showFavorites ? 'page' : undefined}
-            onClick={() => {
-              setFavorites(true);
-              setStatus('all');
-              setTag(null);
-            }}
+            onClick={() => setFavorites(!showFavorites)}
             className={`
               w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors min-h-[44px]
               ${

--- a/src/components/reader/ReaderModal.tsx
+++ b/src/components/reader/ReaderModal.tsx
@@ -86,12 +86,23 @@ export default function ReaderModal({ bookmark, open, onClose, onCycleStatus }: 
     if (open) {
       document.addEventListener('keydown', handleKeyDown);
       document.body.style.overflow = 'hidden';
+      // Push a history entry so the PWA back gesture closes the reader
+      // instead of navigating away from the app.
+      history.pushState({ reader: true }, '');
     }
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
       document.body.style.overflow = '';
     };
   }, [open, handleKeyDown]);
+
+  // Intercept browser/PWA back gesture while reader is open.
+  useEffect(() => {
+    if (!open) return;
+    const handlePopState = () => onClose();
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, [open, onClose]);
 
   // Reset scroll when bookmark changes
   useEffect(() => {

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -103,10 +103,11 @@ export function useBookmarks() {
         old ? [newBookmark, ...old] : [newBookmark],
       );
       toast.success('Bookmark added');
-      // Auto-extract content in background
-      void triggerExtraction(newBookmark);
-      // Auto-fetch metadata, then AI-tag with the enriched bookmark
-      void autoFetchMetadataAndTag(newBookmark);
+      // Fetch metadata first (awaited), THEN trigger extraction.
+      // Extraction's invalidateQueries must not race with the metadata DB write.
+      void autoFetchMetadataAndTag(newBookmark).then(() => {
+        void triggerExtraction(newBookmark);
+      });
     },
     onError: () => toast.error('Failed to add bookmark'),
   });
@@ -396,10 +397,16 @@ export function useBookmarks() {
       if (updates) {
         const { error } = await db.from('bookmarks').update(updates).eq('id', bookmark.id);
         if (!error) {
-          enriched = { ...bookmark, ...updates } as Bookmark;
+          // Merge updates into the CURRENT cache state for this bookmark so we
+          // don't clobber fields (e.g. areas) that were set after the initial insert.
           queryClient.setQueryData<Bookmark[]>(QUERY_KEY, (old) =>
-            old?.map((b) => (b.id === bookmark.id ? enriched : b)),
+            old?.map((b) => (b.id === bookmark.id ? { ...b, ...updates } : b)),
           );
+          enriched = {
+            ...(queryClient
+              .getQueryData<Bookmark[]>(QUERY_KEY)
+              ?.find((b) => b.id === bookmark.id) ?? bookmark),
+          };
         }
       }
     } catch {

--- a/src/lib/__tests__/metadata.test.ts
+++ b/src/lib/__tests__/metadata.test.ts
@@ -125,6 +125,36 @@ describe('fetchMetadata — Twitter', () => {
     expect(result.excerpt).toBe('Hello world tweet text');
   });
 
+  it('strips trailing t.co URL from tweet text', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        author_name: 'Jane Smith',
+        html: '<blockquote class="twitter-tweet"><p lang="en">Great article on AI safety https://t.co/abc123XYZ</p></blockquote>',
+      }),
+    );
+
+    const result = await fetchMetadata('https://twitter.com/user/status/789', 'twitter');
+
+    expect(result.title).toContain('Jane Smith');
+    expect(result.title).toContain('Great article on AI safety');
+    expect(result.title).not.toContain('https://t.co/');
+    expect(result.excerpt).not.toContain('https://t.co/');
+  });
+
+  it('strips t.co URL mid-tweet and trims cleanly', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        author_name: 'Dev User',
+        html: '<blockquote class="twitter-tweet"><p lang="en">Check this out https://t.co/xyz999 really interesting</p></blockquote>',
+      }),
+    );
+
+    const result = await fetchMetadata('https://x.com/user/status/111', 'twitter');
+
+    expect(result.title).not.toContain('https://t.co/');
+    expect(result.excerpt).not.toContain('https://t.co/');
+  });
+
   it('falls back to Microlink when oEmbed fails', async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({}, 404));
     mockFetch.mockResolvedValueOnce(

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -116,6 +116,8 @@ async function fetchTwitterMetadata(url: string): Promise<MetadataResult> {
           ?.replace(/&amp;/g, '&')
           ?.replace(/&lt;/g, '<')
           ?.replace(/&gt;/g, '>')
+          // Twitter appends a t.co tracking URL to every tweet with media/links
+          ?.replace(/https?:\/\/t\.co\/\S+/g, '')
           ?.trim();
 
         return {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -108,8 +108,12 @@ export default function Dashboard({ userEmail, onSignOut, isDemo, sharedUrl }: D
     let cancelled = false;
 
     async function enrichAndTag() {
-      // Phase 1: Fetch missing metadata
-      const missing = currentBookmarks.filter((b) => !b.title);
+      // Phase 1: Fetch missing metadata.
+      // "Missing" means: no title, OR a YouTube bookmark with no channel metadata
+      // (title may have been set by oEmbed but channel/duration weren't saved).
+      const missing = currentBookmarks.filter(
+        (b) => !b.title || (b.source_type === 'youtube' && !b.metadata?.channel),
+      );
       if (missing.length > 0) {
         setMetaProgress({ current: 0, total: missing.length });
         const BATCH_SIZE = 3;
@@ -126,7 +130,8 @@ export default function Dashboard({ userEmail, onSignOut, isDemo, sharedUrl }: D
                 if (result.excerpt && !b.excerpt) updates.excerpt = result.excerpt;
                 if (result.metadata) updates.metadata = { ...b.metadata, ...result.metadata };
                 if (Object.keys(updates).length > 0) {
-                  void db.from('bookmarks').update(updates).eq('id', b.id);
+                  // Await the DB write so it completes before invalidateQueries fires.
+                  await db.from('bookmarks').update(updates).eq('id', b.id);
                 }
               } catch {
                 /* skip */
@@ -139,7 +144,7 @@ export default function Dashboard({ userEmail, onSignOut, isDemo, sharedUrl }: D
           });
         }
         setMetaProgress(null);
-        // Refresh cache so phase 2 reads enriched bookmarks
+        // All DB writes are complete — safe to refetch now.
         await queryClient.invalidateQueries({ queryKey: ['bookmarks'] });
       }
 


### PR DESCRIPTION
## Summary

- **Race A fixed**: `triggerExtraction`'s `invalidateQueries` no longer clobbers metadata — `autoFetchMetadataAndTag` runs and completes before extraction is triggered
- **Race B fixed**: startup batch enrichment now `await`s DB writes before `invalidateQueries`, eliminating a second race on initial load
- **YouTube channel/duration**: startup batch widened to catch bookmarks with title but no `metadata.channel`
- **Areas flash fixed**: metadata cache update merges into live cache state (preserves areas set by `setBookmarkAreas`)
- **Twitter title**: strips `t.co` tracking URLs from extracted tweet text
- **Uncategorized count**: `__untagged__` filter now checks areas only — count matches list
- **PWA back button**: `ReaderModal` pushes a history entry on open; `popstate` closes the reader instead of navigating away from the app
- **Filter independence**: Sidebar/MobileNav nav actions no longer cross-clear filter dimensions; Favorites is a toggle; status/area/favorites are fully orthogonal

## Test Plan

- [ ] Add Substack/blog bookmark — title and metadata appear without pressing refresh
- [ ] Add YouTube bookmark — channel name (and duration if API key set) appear without pressing refresh
- [ ] Add bookmark with areas selected — areas persist after metadata loads (no flash)
- [ ] Add Twitter bookmark that embeds a link — title shows author + tweet text only, no `t.co` URL
- [ ] Areas view → Uncategorized count matches the number of items shown after clicking through
- [ ] In PWA on Android/iOS: open Reader, press back — reader closes, app stays open
- [ ] Select an area filter, then click Favorites — both filters active simultaneously (AND behaviour)
- [ ] Select area + Favorites, then click Unread — area and favorites persist, only status changes
- [ ] All 139 tests pass (`npm run test`)

Closes #16