### PR TITLE
feat: book capture without URL — optional URL, author field

### DIFF
--- a/docs/log/v3.1-book-capture-without-url.md
+++ b/docs/log/v3.1-book-capture-without-url.md
@@ -1,0 +1,53 @@
+# v3.1 — Book Capture Without URL
+
+**Issue:** #18
+**Branch:** feat/18-book-capture-without-url
+**Date:** 2026-02-24
+**Status:** Shipped
+
+## What Was Built
+
+Made URL optional for the `book` source type, added an `author` field, and made the Books tab fully usable as a personal reading log — without requiring a URL.
+
+### Features
+- **"Log a book" toggle** in AddBookmarkModal — switches to book mode where title is required, URL is optional, and an author field appears
+- **Author field** in both AddBookmarkModal (book mode) and EditBookmarkModal (when source = book)
+- **BookmarkCard** shows author instead of domain for URL-less books; hides favicon and external link icon
+- **DetailPanel / MetadataHeader** shows author in meta stats; hides domain row, open link, refresh, and "extract failed" for URL-less books
+- **Obsidian export** omits `url:` from frontmatter and "Open original" link for URL-less books; includes `author:` in frontmatter
+
+### Sentinel URL Pattern
+URL-less books use `book://no-url` as the sentinel value (DB column stays NOT NULL). `isBookWithoutUrl()` helper in `utils.ts` checks `source_type === 'book' && !url.startsWith('http')`. All UI components use this helper to conditionally hide URL-specific elements.
+
+## Key Decisions
+
+- **Sentinel URL** over DB schema change — avoids a migration, keeps the `url NOT NULL` constraint, and is cleanly abstracted behind `isBookWithoutUrl()`
+- **`metadata.author`** via JSONB — no migration needed; follows the existing pattern for `channel`, `duration`, etc.
+- **Book mode toggle** (not a separate modal) — keeps the UI surface small; same form adapts
+- **`'book'` added to `SKIP_EXTRACTION_SOURCES`** — no content extraction attempt for books (no URL to scrape)
+- **`autoFetchMetadataAndTag` early-returns for URL-less books** — still runs AI tagging with title context if an API key is present
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/types/index.ts` | Added `author?: string` to `BookmarkMetadata` |
+| `src/lib/utils.ts` | Added `isBookWithoutUrl()` helper |
+| `src/hooks/useBookmarks.ts` | `addBookmark` accepts `url?` and `metadata?`; `'book'` added to `SKIP_EXTRACTION_SOURCES`; `autoFetchMetadataAndTag` skips URL-less books |
+| `src/components/modals/AddBookmarkModal.tsx` | Book mode toggle, author field, optional URL, `source_type: 'book'` forced |
+| `src/components/modals/EditBookmarkModal.tsx` | Author field for books, URL not required when source is book, saves metadata |
+| `src/components/feed/BookmarkCard.tsx` | Shows author, hides favicon/domain/external link for URL-less books |
+| `src/components/detail/MetadataHeader.tsx` | Shows author, hides domain row / open link / refresh / extract-failed for URL-less books |
+| `src/lib/obsidian.ts` | Omits url frontmatter and "Open original" for URL-less books; adds `author:` frontmatter |
+| `src/components/__tests__/AddBookmarkModal.test.tsx` | +6 book mode tests (toggle, submit, author, no-URL flow) |
+| `src/lib/__tests__/obsidian.test.ts` | New — 7 tests for standard and URL-less book export |
+| `public/sw.js` | Bumped cache to `contentdeck-v3.0.7` |
+
+## Test Results
+
+154 tests passing (up from 139 in Session 1).
+
+## Gotchas
+
+- `generateMarkdown` declared `noUrl` twice — caught and removed the duplicate
+- TypeScript `mock.calls[0][0]` access needs `?.` for `noUncheckedIndexedAccess` compatibility

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'contentdeck-v3.0.6'
+const CACHE_NAME = 'contentdeck-v3.0.7'
 
 self.addEventListener('install', () => {
   // Don't skip waiting — let the app decide when to activate

--- a/src/components/__tests__/AddBookmarkModal.test.tsx
+++ b/src/components/__tests__/AddBookmarkModal.test.tsx
@@ -67,3 +67,79 @@ describe('AddBookmarkModal', () => {
     expect(screen.getByText('twitter')).toBeInTheDocument();
   });
 });
+
+describe('AddBookmarkModal — book mode', () => {
+  it('shows book mode toggle button', () => {
+    render(<AddBookmarkModal {...defaultProps} />);
+    expect(screen.getByText('Log a book without a URL')).toBeInTheDocument();
+  });
+
+  it('enters book mode when toggle is clicked', async () => {
+    const user = userEvent.setup();
+    render(<AddBookmarkModal {...defaultProps} />);
+    await user.click(screen.getByText('Log a book without a URL'));
+    expect(screen.getByText('Logging a book (no URL needed)')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Book title')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Author name')).toBeInTheDocument();
+    expect(screen.getByText('Log Book')).toBeInTheDocument();
+  });
+
+  it('submit button enabled when title is filled (book mode, no URL)', async () => {
+    const user = userEvent.setup();
+    render(<AddBookmarkModal {...defaultProps} />);
+    await user.click(screen.getByText('Log a book without a URL'));
+    expect(screen.getByText('Log Book').closest('button')).toBeDisabled();
+    await user.type(screen.getByPlaceholderText('Book title'), 'Atomic Habits');
+    expect(screen.getByText('Log Book').closest('button')).not.toBeDisabled();
+  });
+
+  it('calls onAdd with source_type book and no url when no URL is entered', async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn();
+    render(<AddBookmarkModal {...defaultProps} onAdd={onAdd} />);
+    await user.click(screen.getByText('Log a book without a URL'));
+    await user.type(screen.getByPlaceholderText('Book title'), 'Deep Work');
+    await user.type(screen.getByPlaceholderText('Author name'), 'Cal Newport');
+    await user.click(screen.getByText('Log Book'));
+    expect(onAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Deep Work',
+        source_type: 'book',
+        metadata: { author: 'Cal Newport' },
+      }),
+    );
+    const call = onAdd.mock.calls[0]?.[0] as { url?: string };
+    expect(call.url).toBeUndefined();
+  });
+
+  it('calls onAdd with url when URL is provided in book mode', async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn();
+    render(<AddBookmarkModal {...defaultProps} onAdd={onAdd} />);
+    await user.click(screen.getByText('Log a book without a URL'));
+    await user.type(
+      screen.getByPlaceholderText('https://... (optional)'),
+      'https://books.example.com/atomic-habits',
+    );
+    await user.type(screen.getByPlaceholderText('Book title'), 'Atomic Habits');
+    await user.click(screen.getByText('Log Book'));
+    expect(onAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://books.example.com/atomic-habits',
+        title: 'Atomic Habits',
+        source_type: 'book',
+      }),
+    );
+  });
+
+  it('omits metadata when no author is entered in book mode', async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn();
+    render(<AddBookmarkModal {...defaultProps} onAdd={onAdd} />);
+    await user.click(screen.getByText('Log a book without a URL'));
+    await user.type(screen.getByPlaceholderText('Book title'), 'No Author Book');
+    await user.click(screen.getByText('Log Book'));
+    const call = onAdd.mock.calls[0]?.[0] as { metadata?: unknown };
+    expect(call.metadata).toBeUndefined();
+  });
+});

--- a/src/components/detail/MetadataHeader.tsx
+++ b/src/components/detail/MetadataHeader.tsx
@@ -8,7 +8,7 @@ import {
   AlertCircle,
 } from 'lucide-react';
 import { SourceBadge, StatusBadge } from '../ui/Badge';
-import { getDomain, getFaviconUrl, timeAgo, formatDate } from '../../lib/utils';
+import { getDomain, getFaviconUrl, timeAgo, formatDate, isBookWithoutUrl } from '../../lib/utils';
 import type { Bookmark, Status } from '../../types';
 import { STATUS_NEXT } from '../../types';
 
@@ -27,7 +27,8 @@ export default function MetadataHeader({
   onRefreshMetadata,
   isRefreshing,
 }: MetadataHeaderProps) {
-  const domain = getDomain(b.url);
+  const noUrl = isBookWithoutUrl(b);
+  const domain = noUrl ? null : getDomain(b.url);
 
   return (
     <div className="space-y-3">
@@ -40,33 +41,35 @@ export default function MetadataHeader({
 
       {/* Title */}
       <h2 className="text-lg font-semibold text-surface-900 dark:text-surface-100 leading-snug">
-        {b.title || b.url}
+        {b.title || (noUrl ? 'Untitled Book' : b.url)}
       </h2>
 
-      {/* Domain row */}
-      <div className="flex items-center gap-2 text-sm text-surface-500 dark:text-surface-400">
-        <img src={getFaviconUrl(b.url)} alt="" className="w-4 h-4" loading="lazy" />
-        <span>{domain}</span>
-        <div className="ml-auto flex items-center gap-2">
-          <button
-            onClick={() => onRefreshMetadata(b)}
-            disabled={isRefreshing}
-            className="inline-flex items-center gap-1 text-surface-400 hover:text-primary-600 dark:hover:text-primary-400 text-xs font-medium disabled:opacity-50 min-w-[32px] min-h-[32px] justify-center"
-            aria-label="Refresh metadata"
-            title="Refresh metadata"
-          >
-            <RefreshCw size={12} className={isRefreshing ? 'animate-spin' : ''} />
-          </button>
-          <a
-            href={b.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 text-primary-600 dark:text-primary-400 hover:underline text-xs font-medium"
-          >
-            Open <ExternalLink size={12} />
-          </a>
+      {/* Domain row — hidden for URL-less books */}
+      {!noUrl && (
+        <div className="flex items-center gap-2 text-sm text-surface-500 dark:text-surface-400">
+          <img src={getFaviconUrl(b.url)} alt="" className="w-4 h-4" loading="lazy" />
+          <span>{domain}</span>
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              onClick={() => onRefreshMetadata(b)}
+              disabled={isRefreshing}
+              className="inline-flex items-center gap-1 text-surface-400 hover:text-primary-600 dark:hover:text-primary-400 text-xs font-medium disabled:opacity-50 min-w-[32px] min-h-[32px] justify-center"
+              aria-label="Refresh metadata"
+              title="Refresh metadata"
+            >
+              <RefreshCw size={12} className={isRefreshing ? 'animate-spin' : ''} />
+            </button>
+            <a
+              href={b.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-primary-600 dark:text-primary-400 hover:underline text-xs font-medium"
+            >
+              Open <ExternalLink size={12} />
+            </a>
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Badges + Actions row */}
       <div className="flex items-center gap-2 flex-wrap">
@@ -117,7 +120,7 @@ export default function MetadataHeader({
           </span>
         )}
 
-        {b.content_status === 'failed' && (
+        {b.content_status === 'failed' && !noUrl && (
           <button
             onClick={() => onRefreshMetadata(b)}
             disabled={isRefreshing}
@@ -133,6 +136,7 @@ export default function MetadataHeader({
       <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-surface-400 dark:text-surface-500">
         <span>Added {timeAgo(b.created_at)}</span>
         <span title={formatDate(b.created_at)}>{formatDate(b.created_at)}</span>
+        {b.metadata?.author && <span>{b.metadata.author}</span>}
         {b.metadata?.reading_time && (
           <span className="flex items-center gap-1">
             <Clock size={12} /> {b.metadata.reading_time} min read

--- a/src/components/feed/BookmarkCard.tsx
+++ b/src/components/feed/BookmarkCard.tsx
@@ -1,6 +1,6 @@
 import { Heart, Trash2, ExternalLink, Clock, FileText } from 'lucide-react';
 import { SourceBadge, StatusBadge } from '../ui/Badge';
-import { timeAgo, getDomain, getFaviconUrl, truncate } from '../../lib/utils';
+import { timeAgo, getDomain, getFaviconUrl, truncate, isBookWithoutUrl } from '../../lib/utils';
 import { useUI } from '../../context/UIProvider';
 import type { Bookmark, Status } from '../../types';
 import { STATUS_NEXT } from '../../types';
@@ -27,7 +27,8 @@ export default function BookmarkCard({
   onClick,
 }: BookmarkCardProps) {
   const { setTag } = useUI();
-  const domain = getDomain(b.url);
+  const noUrl = isBookWithoutUrl(b);
+  const domain = noUrl ? null : getDomain(b.url);
   const readingTime = b.metadata?.reading_time;
 
   function handleClick() {
@@ -91,13 +92,18 @@ export default function BookmarkCard({
 
         {/* Title */}
         <h3 className="text-sm font-medium text-surface-900 dark:text-surface-100 line-clamp-2 mb-1">
-          {b.title || truncate(b.url, 60)}
+          {b.title || (noUrl ? 'Untitled Book' : truncate(b.url, 60))}
         </h3>
 
         {/* Domain + metadata */}
         <div className="flex items-center gap-2 text-xs text-surface-500 dark:text-surface-400">
-          <img src={getFaviconUrl(b.url)} alt="" className="w-3.5 h-3.5" loading="lazy" />
-          <span>{domain}</span>
+          {!noUrl && (
+            <img src={getFaviconUrl(b.url)} alt="" className="w-3.5 h-3.5" loading="lazy" />
+          )}
+          {domain && <span>{domain}</span>}
+          {b.metadata?.author && (
+            <span>{noUrl ? b.metadata.author : `· ${b.metadata.author}`}</span>
+          )}
           {b.metadata?.duration && (
             <span className="flex items-center gap-0.5">
               &middot; <Clock size={11} /> {b.metadata.duration}
@@ -165,16 +171,18 @@ export default function BookmarkCard({
         >
           <Heart size={16} fill={b.is_favorited ? 'currentColor' : 'none'} />
         </button>
-        <a
-          href={b.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={(e) => e.stopPropagation()}
-          className="p-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800 text-surface-400 min-w-[36px] min-h-[36px] flex items-center justify-center"
-          aria-label="Open in new tab"
-        >
-          <ExternalLink size={16} />
-        </a>
+        {!noUrl && (
+          <a
+            href={b.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="p-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800 text-surface-400 min-w-[36px] min-h-[36px] flex items-center justify-center"
+            aria-label="Open in new tab"
+          >
+            <ExternalLink size={16} />
+          </a>
+        )}
         <button
           onClick={handleDelete}
           className="p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 text-surface-400 hover:text-red-500 min-w-[36px] min-h-[36px] flex items-center justify-center"

--- a/src/components/modals/AddBookmarkModal.tsx
+++ b/src/components/modals/AddBookmarkModal.tsx
@@ -4,17 +4,18 @@ import Button from '../ui/Button';
 import TagAreaInput from '../ui/TagAreaInput';
 import { detectSourceType } from '../../lib/utils';
 import { SourceBadge } from '../ui/Badge';
-import type { SourceType, TagArea } from '../../types';
+import type { BookmarkMetadata, SourceType, TagArea } from '../../types';
 
 interface AddBookmarkModalProps {
   open: boolean;
   onClose: () => void;
   onAdd: (data: {
-    url: string;
+    url?: string;
     title?: string;
     source_type?: string;
     tags?: string[];
     areaIds?: string[];
+    metadata?: BookmarkMetadata;
   }) => void;
   isPending: boolean;
   initialUrl?: string;
@@ -31,8 +32,10 @@ export default function AddBookmarkModal({
   allAreas,
   allTags,
 }: AddBookmarkModalProps) {
+  const [bookMode, setBookMode] = useState(false);
   const [url, setUrl] = useState('');
   const [title, setTitle] = useState('');
+  const [author, setAuthor] = useState('');
   const [detectedSource, setDetectedSource] = useState<SourceType | null>(null);
   const [tags, setTags] = useState<string[]>([]);
   const [selectedAreas, setSelectedAreas] = useState<TagArea[]>([]);
@@ -45,6 +48,19 @@ export default function AddBookmarkModal({
     }
   }, [open, initialUrl]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Reset form when modal closes
+  useEffect(() => {
+    if (!open) {
+      setUrl('');
+      setTitle('');
+      setAuthor('');
+      setDetectedSource(null);
+      setTags([]);
+      setSelectedAreas([]);
+      // Keep bookMode — user may want to log multiple books in a row
+    }
+  }, [open]);
+
   function handleUrlChange(value: string) {
     setUrl(value);
     if (value.trim()) {
@@ -56,69 +72,127 @@ export default function AddBookmarkModal({
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!url.trim()) return;
 
-    onAdd({
-      url: url.trim(),
-      title: title.trim() || undefined,
-      source_type: detectedSource ?? undefined,
-      tags: tags.length > 0 ? tags : undefined,
-      areaIds: selectedAreas.length > 0 ? selectedAreas.map((a) => a.id) : undefined,
-    });
+    if (bookMode) {
+      if (!title.trim()) return;
+      onAdd({
+        url: url.trim() || undefined,
+        title: title.trim(),
+        source_type: 'book',
+        tags: tags.length > 0 ? tags : undefined,
+        areaIds: selectedAreas.length > 0 ? selectedAreas.map((a) => a.id) : undefined,
+        metadata: author.trim() ? { author: author.trim() } : undefined,
+      });
+    } else {
+      if (!url.trim()) return;
+      onAdd({
+        url: url.trim(),
+        title: title.trim() || undefined,
+        source_type: detectedSource ?? undefined,
+        tags: tags.length > 0 ? tags : undefined,
+        areaIds: selectedAreas.length > 0 ? selectedAreas.map((a) => a.id) : undefined,
+      });
+    }
 
-    // Reset form
     setUrl('');
     setTitle('');
+    setAuthor('');
     setDetectedSource(null);
     setTags([]);
     setSelectedAreas([]);
     onClose();
   }
 
+  const canSubmit = bookMode ? title.trim().length > 0 : url.trim().length > 0;
+
   return (
     <Modal open={open} onClose={onClose} title="Add Bookmark">
       <form onSubmit={handleSubmit} className="space-y-4">
-        {/* URL */}
+        {/* Book mode toggle */}
+        <button
+          type="button"
+          onClick={() => setBookMode((m) => !m)}
+          className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg border text-sm font-medium transition-colors ${
+            bookMode
+              ? 'border-primary-500 bg-primary-600/10 text-primary-700 dark:text-primary-300'
+              : 'border-surface-200 dark:border-surface-700 text-surface-500 dark:text-surface-400 hover:border-surface-300 dark:hover:border-surface-600'
+          }`}
+        >
+          <span>📚</span>
+          {bookMode ? 'Logging a book (no URL needed)' : 'Log a book without a URL'}
+        </button>
+
+        {/* URL — required normally, optional in book mode */}
         <div>
           <label
             htmlFor="add-url"
             className="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-1"
           >
-            URL
+            URL{' '}
+            {bookMode && <span className="text-surface-400 font-normal">(optional for books)</span>}
           </label>
           <input
             id="add-url"
             type="url"
             value={url}
             onChange={(e) => handleUrlChange(e.target.value)}
-            placeholder="https://..."
-            required
+            placeholder={bookMode ? 'https://... (optional)' : 'https://...'}
+            required={!bookMode}
             className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 min-h-[44px]"
           />
-          {detectedSource && (
+          {!bookMode && detectedSource && (
             <div className="mt-2">
               <SourceBadge source={detectedSource} />
             </div>
           )}
+          {bookMode && (
+            <div className="mt-2">
+              <SourceBadge source="book" />
+            </div>
+          )}
         </div>
 
-        {/* Title */}
+        {/* Title — optional normally, required in book mode */}
         <div>
           <label
             htmlFor="add-title"
             className="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-1"
           >
-            Title <span className="text-surface-400 font-normal">(optional, auto-fetched)</span>
+            Title{' '}
+            <span className="text-surface-400 font-normal">
+              {bookMode ? '(required)' : '(optional, auto-fetched)'}
+            </span>
           </label>
           <input
             id="add-title"
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            placeholder="Page title"
+            placeholder={bookMode ? 'Book title' : 'Page title'}
+            required={bookMode}
             className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 min-h-[44px]"
           />
         </div>
+
+        {/* Author — book mode only */}
+        {bookMode && (
+          <div>
+            <label
+              htmlFor="add-author"
+              className="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-1"
+            >
+              Author <span className="text-surface-400 font-normal">(optional)</span>
+            </label>
+            <input
+              id="add-author"
+              type="text"
+              value={author}
+              onChange={(e) => setAuthor(e.target.value)}
+              placeholder="Author name"
+              className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 min-h-[44px]"
+            />
+          </div>
+        )}
 
         {/* Areas & Tags */}
         <div>
@@ -145,8 +219,8 @@ export default function AddBookmarkModal({
           <Button type="button" variant="ghost" onClick={onClose}>
             Cancel
           </Button>
-          <Button type="submit" disabled={!url.trim() || isPending}>
-            {isPending ? 'Saving...' : 'Save Bookmark'}
+          <Button type="submit" disabled={!canSubmit || isPending}>
+            {isPending ? 'Saving...' : bookMode ? 'Log Book' : 'Save Bookmark'}
           </Button>
         </div>
       </form>

--- a/src/components/modals/EditBookmarkModal.tsx
+++ b/src/components/modals/EditBookmarkModal.tsx
@@ -27,6 +27,7 @@ export default function EditBookmarkModal({
 }: EditBookmarkModalProps) {
   const [url, setUrl] = useState('');
   const [title, setTitle] = useState('');
+  const [author, setAuthor] = useState('');
   const [sourceType, setSourceType] = useState<SourceType>('blog');
   const [status, setStatus] = useState<Status>('unread');
   const [tags, setTags] = useState<string[]>([]);
@@ -35,8 +36,10 @@ export default function EditBookmarkModal({
   // Sync form state when bookmark changes
   useEffect(() => {
     if (bookmark) {
-      setUrl(bookmark.url);
+      // Show empty string for sentinel URL so the field is blank for books
+      setUrl(bookmark.url.startsWith('http') ? bookmark.url : '');
       setTitle(bookmark.title ?? '');
+      setAuthor(bookmark.metadata?.author ?? '');
       setSourceType(bookmark.source_type);
       setStatus(bookmark.status);
       setTags(bookmark.tags ?? []);
@@ -46,16 +49,26 @@ export default function EditBookmarkModal({
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!bookmark || !url.trim()) return;
+    if (!bookmark) return;
+
+    const isBook = sourceType === 'book';
+    // URL required only when not a book
+    if (!isBook && !url.trim()) return;
+
+    const savedUrl = url.trim() || (isBook ? 'book://no-url' : '');
+    const updatedMetadata = author.trim()
+      ? { ...bookmark.metadata, author: author.trim() }
+      : bookmark.metadata;
 
     onSave(
       bookmark.id,
       {
-        url: url.trim(),
+        url: savedUrl,
         title: title.trim() || null,
         source_type: sourceType,
         status,
         tags,
+        metadata: updatedMetadata,
       },
       selectedAreas.map((a) => a.id),
     );
@@ -63,6 +76,9 @@ export default function EditBookmarkModal({
   }
 
   if (!bookmark) return null;
+
+  const isBook = sourceType === 'book';
+  const canSubmit = isBook ? true : url.trim().length > 0;
 
   return (
     <Modal open={open} onClose={onClose} title="Edit Bookmark">
@@ -73,14 +89,16 @@ export default function EditBookmarkModal({
             htmlFor="edit-url"
             className="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-1"
           >
-            URL
+            URL{' '}
+            {isBook && <span className="text-surface-400 font-normal">(optional for books)</span>}
           </label>
           <input
             id="edit-url"
             type="url"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
-            required
+            placeholder={isBook ? 'https://... (optional)' : 'https://...'}
+            required={!isBook}
             className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 min-h-[44px]"
           />
         </div>
@@ -98,10 +116,30 @@ export default function EditBookmarkModal({
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            placeholder="Page title"
+            placeholder="Title"
             className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 min-h-[44px]"
           />
         </div>
+
+        {/* Author — book only */}
+        {isBook && (
+          <div>
+            <label
+              htmlFor="edit-author"
+              className="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-1"
+            >
+              Author <span className="text-surface-400 font-normal">(optional)</span>
+            </label>
+            <input
+              id="edit-author"
+              type="text"
+              value={author}
+              onChange={(e) => setAuthor(e.target.value)}
+              placeholder="Author name"
+              className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 min-h-[44px]"
+            />
+          </div>
+        )}
 
         {/* Source Type + Status row */}
         <div className="grid grid-cols-2 gap-3">
@@ -177,7 +215,7 @@ export default function EditBookmarkModal({
           <Button type="button" variant="ghost" onClick={onClose}>
             Cancel
           </Button>
-          <Button type="submit" disabled={!url.trim() || isPending}>
+          <Button type="submit" disabled={!canSubmit || isPending}>
             {isPending ? 'Saving...' : 'Save Changes'}
           </Button>
         </div>

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -3,7 +3,7 @@ import { useSupabase } from '../context/SupabaseProvider';
 import { useToast } from '../components/ui/Toast';
 import { fetchMetadata } from '../lib/metadata';
 import { suggestTags } from '../lib/ai';
-import { detectSourceType } from '../lib/utils';
+import { detectSourceType, isBookWithoutUrl } from '../lib/utils';
 import type { Bookmark, TagArea, Status, NoteType, Note, BookmarkMetadata } from '../types';
 
 const QUERY_KEY = ['bookmarks'] as const;
@@ -74,23 +74,27 @@ export function useBookmarks() {
 
   const addBookmark = useMutation({
     mutationFn: async (bookmark: {
-      url: string;
+      url?: string;
       title?: string;
       source_type?: string;
       tags?: string[];
       notes?: Bookmark['notes'];
+      metadata?: BookmarkMetadata;
     }) => {
+      const url = bookmark.url || 'book://no-url';
+      const sourceType =
+        bookmark.source_type || (url.startsWith('http') ? detectSourceType(url) : 'book');
       const { data, error } = (await db
         .from('bookmarks')
         .insert({
-          url: bookmark.url,
+          url,
           title: bookmark.title || null,
-          source_type: bookmark.source_type || detectSourceType(bookmark.url),
+          source_type: sourceType,
           tags: bookmark.tags || [],
           notes: bookmark.notes || [],
           status: 'unread',
           is_favorited: false,
-          metadata: {},
+          metadata: bookmark.metadata || {},
           synced: false,
         })
         .select()
@@ -390,6 +394,14 @@ export function useBookmarks() {
 
   /** Fetch metadata then AI-tag — used on add so AI has title context */
   async function autoFetchMetadataAndTag(bookmark: Bookmark) {
+    // Skip metadata fetch for URL-less books — no URL to scrape
+    if (isBookWithoutUrl(bookmark)) {
+      if (bookmark.tags.length === 0 && bookmark.title && localStorage.getItem('openrouter_key')) {
+        void autoSuggestTags(bookmark);
+      }
+      return;
+    }
+
     let enriched = bookmark;
     try {
       const result = await fetchMetadata(bookmark.url, bookmark.source_type);
@@ -446,7 +458,7 @@ export function useBookmarks() {
   }
 
   const isDemo = localStorage.getItem('contentdeck_demo') === 'true';
-  const SKIP_EXTRACTION_SOURCES = ['youtube', 'twitter'];
+  const SKIP_EXTRACTION_SOURCES = ['youtube', 'twitter', 'book'];
 
   async function triggerExtraction(bookmark: Bookmark) {
     if (isDemo) return;

--- a/src/lib/__tests__/obsidian.test.ts
+++ b/src/lib/__tests__/obsidian.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { generateMarkdown } from '../obsidian';
+import type { Bookmark } from '../../types';
+
+function makeBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
+  return {
+    id: 'test-id',
+    url: 'https://example.com/article',
+    title: 'Test Article',
+    image: null,
+    excerpt: null,
+    source_type: 'blog',
+    status: 'unread',
+    is_favorited: false,
+    notes: [],
+    tags: [],
+    areas: [],
+    metadata: {},
+    content: {},
+    content_status: 'pending',
+    content_fetched_at: null,
+    synced: false,
+    created_at: '2024-01-15T10:00:00Z',
+    status_changed_at: '2024-01-15T10:00:00Z',
+    started_reading_at: null,
+    finished_at: null,
+    ...overrides,
+  };
+}
+
+describe('generateMarkdown — standard bookmark', () => {
+  it('includes url in frontmatter', () => {
+    const md = generateMarkdown(makeBookmark());
+    expect(md).toContain('url: "https://example.com/article"');
+  });
+
+  it('includes Open original link', () => {
+    const md = generateMarkdown(makeBookmark());
+    expect(md).toContain('> [Open original](https://example.com/article)');
+    expect(md).toContain('example.com');
+  });
+
+  it('includes author in frontmatter when present', () => {
+    const md = generateMarkdown(makeBookmark({ metadata: { author: 'Jane Smith' } }));
+    expect(md).toContain('author: "Jane Smith"');
+  });
+
+  it('includes channel in frontmatter for YouTube', () => {
+    const md = generateMarkdown(
+      makeBookmark({
+        url: 'https://youtube.com/watch?v=abc',
+        source_type: 'youtube',
+        metadata: { channel: 'Tech Channel', duration: '10:30' },
+      }),
+    );
+    expect(md).toContain('channel: "Tech Channel"');
+  });
+});
+
+describe('generateMarkdown — book without URL', () => {
+  const bookNoUrl = makeBookmark({
+    url: 'book://no-url',
+    title: 'Deep Work',
+    source_type: 'book',
+    metadata: { author: 'Cal Newport' },
+  });
+
+  it('omits sentinel URL from frontmatter', () => {
+    const md = generateMarkdown(bookNoUrl);
+    expect(md).not.toContain('book://no-url');
+  });
+
+  it('omits Open original link', () => {
+    const md = generateMarkdown(bookNoUrl);
+    expect(md).not.toContain('Open original');
+  });
+
+  it('includes title as heading', () => {
+    const md = generateMarkdown(bookNoUrl);
+    expect(md).toContain('# Deep Work');
+  });
+
+  it('includes author in frontmatter', () => {
+    const md = generateMarkdown(bookNoUrl);
+    expect(md).toContain('author: "Cal Newport"');
+  });
+
+  it('uses Untitled Book fallback when no title', () => {
+    const md = generateMarkdown(
+      makeBookmark({ url: 'book://no-url', title: null, source_type: 'book' }),
+    );
+    expect(md).toContain('# Untitled Book');
+  });
+});

--- a/src/lib/obsidian.ts
+++ b/src/lib/obsidian.ts
@@ -1,5 +1,5 @@
 import type { Bookmark } from '../types';
-import { formatDate, getDomain } from './utils';
+import { formatDate, getDomain, isBookWithoutUrl } from './utils';
 import { SOURCE_LABELS } from '../types';
 
 /** Escape a string for use as a YAML double-quoted value */
@@ -16,9 +16,11 @@ function yamlEscape(s: string): string {
 export function generateMarkdown(bookmark: Bookmark): string {
   const lines: string[] = [];
 
+  const noUrl = isBookWithoutUrl(bookmark);
+
   // YAML frontmatter
   lines.push('---');
-  lines.push(`url: "${yamlEscape(bookmark.url)}"`);
+  if (!noUrl) lines.push(`url: "${yamlEscape(bookmark.url)}"`);
   if (bookmark.title) lines.push(`title: "${yamlEscape(bookmark.title)}"`);
   lines.push(`source: ${SOURCE_LABELS[bookmark.source_type]}`);
   lines.push(`status: ${bookmark.status}`);
@@ -33,17 +35,20 @@ export function generateMarkdown(bookmark: Bookmark): string {
   if (bookmark.metadata?.reading_time)
     lines.push(`reading_time: ${bookmark.metadata.reading_time} min`);
   if (bookmark.metadata?.channel) lines.push(`channel: "${yamlEscape(bookmark.metadata.channel)}"`);
+  if (bookmark.metadata?.author) lines.push(`author: "${yamlEscape(bookmark.metadata.author)}"`);
 
   lines.push('---');
   lines.push('');
 
   // Title
-  lines.push(`# ${bookmark.title || bookmark.url}`);
+  lines.push(`# ${bookmark.title || (noUrl ? 'Untitled Book' : bookmark.url)}`);
   lines.push('');
 
-  // Link
-  lines.push(`> [Open original](${bookmark.url}) — ${getDomain(bookmark.url)}`);
-  lines.push('');
+  // Link — omitted for URL-less books
+  if (!noUrl) {
+    lines.push(`> [Open original](${bookmark.url}) — ${getDomain(bookmark.url)}`);
+    lines.push('');
+  }
 
   // Excerpt
   if (bookmark.excerpt) {
@@ -88,7 +93,8 @@ export function generateMarkdown(bookmark: Bookmark): string {
 
 /** Generate a safe filename from a bookmark title */
 function safeFilename(bookmark: Bookmark): string {
-  const name = bookmark.title || getDomain(bookmark.url);
+  const name =
+    bookmark.title || (isBookWithoutUrl(bookmark) ? 'Untitled Book' : getDomain(bookmark.url));
   return (
     name
       .replace(/[<>:"/\\|?*]/g, '')

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -60,6 +60,11 @@ export function getFaviconUrl(url: string): string {
   return `https://www.google.com/s2/favicons?domain=${domain}&sz=32`;
 }
 
+/** Check if a bookmark is a book entry without a real URL */
+export function isBookWithoutUrl(bookmark: { source_type: string; url: string }): boolean {
+  return bookmark.source_type === 'book' && !bookmark.url.startsWith('http');
+}
+
 /** Truncate text to a max length */
 export function truncate(text: string, max: number): string {
   if (text.length <= max) return text;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,7 @@ export interface BookmarkMetadata {
   channel?: string;
   word_count?: number;
   reading_time?: number;
+  author?: string;
 }
 
 export interface BookmarkContent {


### PR DESCRIPTION
## Summary

- Adds a **"Log a book" toggle** in AddBookmarkModal — book mode requires title, makes URL optional, and shows an author field
- Books without URLs use a `book://no-url` sentinel; `isBookWithoutUrl()` helper drives conditional UI in card, detail panel, and Obsidian export
- `BookmarkMetadata` gains an `author` field (JSONB, no migration needed); author is shown in card and detail view

## Test plan

- [ ] Click "Log a book without a URL" toggle → form switches to book mode
- [ ] Enter book title (required) + author (optional) — no URL — hit "Log Book" → bookmark appears in Books tab with author shown, no broken link icon
- [ ] Open detail panel for URL-less book → domain row hidden, no "Open" link, author in meta stats
- [ ] Edit a book → author field appears, URL field is optional
- [ ] Export URL-less book to Obsidian → no `url:` in frontmatter, no "Open original" link, `author:` present
- [ ] Add a book WITH a URL (e.g. Google Books link) → functions like a normal bookmark
- [ ] All 154 tests pass: `npm run test`

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)