### PR TITLE
feat: full Sentry error coverage (#25)

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import * as Sentry from '@sentry/react';
 import { supabase } from '../lib/supabase';
 import type { User, Session } from '@supabase/supabase-js';
 
@@ -9,11 +10,17 @@ export function useAuth() {
 
   useEffect(() => {
     // Get initial session
-    void supabase.auth.getSession().then(({ data: { session: s } }) => {
-      setSession(s);
-      setUser(s?.user ?? null);
-      setLoading(false);
-    });
+    void supabase.auth
+      .getSession()
+      .then(({ data: { session: s } }) => {
+        setSession(s);
+        setUser(s?.user ?? null);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        Sentry.captureException(err);
+        setLoading(false);
+      });
 
     // Listen for auth state changes (login, logout, token refresh)
     const {

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import * as Sentry from '@sentry/react';
 import { useSupabase } from '../context/SupabaseProvider';
 import { useToast } from '../components/ui/Toast';
 import { fetchMetadata } from '../lib/metadata';
@@ -109,11 +110,18 @@ export function useBookmarks() {
       toast.success('Bookmark added');
       // Fetch metadata first (awaited), THEN trigger extraction.
       // Extraction's invalidateQueries must not race with the metadata DB write.
-      void autoFetchMetadataAndTag(newBookmark).then(() => {
-        void triggerExtraction(newBookmark);
-      });
+      void autoFetchMetadataAndTag(newBookmark)
+        .then(() => {
+          void triggerExtraction(newBookmark);
+        })
+        .catch((err: unknown) => {
+          Sentry.captureException(err);
+        });
     },
-    onError: () => toast.error('Failed to add bookmark'),
+    onError: (err) => {
+      Sentry.captureException(err);
+      toast.error('Failed to add bookmark');
+    },
   });
 
   const deleteBookmark = useMutation({
@@ -127,7 +135,8 @@ export function useBookmarks() {
       queryClient.setQueryData<Bookmark[]>(QUERY_KEY, (old) => old?.filter((b) => b.id !== id));
       return { prev };
     },
-    onError: (_err, _id, context) => {
+    onError: (err, _id, context) => {
+      Sentry.captureException(err);
       if (context?.prev) queryClient.setQueryData(QUERY_KEY, context.prev);
       toast.error('Failed to delete');
     },
@@ -147,7 +156,8 @@ export function useBookmarks() {
       );
       return { prev };
     },
-    onError: (_err, _vars, context) => {
+    onError: (err, _vars, context) => {
+      Sentry.captureException(err);
       if (context?.prev) queryClient.setQueryData(QUERY_KEY, context.prev);
       toast.error('Update failed');
     },
@@ -176,7 +186,8 @@ export function useBookmarks() {
       );
       return { prev };
     },
-    onError: (_err, _vars, context) => {
+    onError: (err, _vars, context) => {
+      Sentry.captureException(err);
       if (context?.prev) queryClient.setQueryData(QUERY_KEY, context.prev);
       toast.error('Update failed');
     },
@@ -197,7 +208,8 @@ export function useBookmarks() {
       );
       return { prev };
     },
-    onError: (_err, _vars, context) => {
+    onError: (err, _vars, context) => {
+      Sentry.captureException(err);
       if (context?.prev) queryClient.setQueryData(QUERY_KEY, context.prev);
       toast.error('Bulk update failed');
     },
@@ -218,7 +230,8 @@ export function useBookmarks() {
       );
       return { prev };
     },
-    onError: (_err, _ids, context) => {
+    onError: (err, _ids, context) => {
+      Sentry.captureException(err);
       if (context?.prev) queryClient.setQueryData(QUERY_KEY, context.prev);
       toast.error('Bulk delete failed');
     },
@@ -261,7 +274,8 @@ export function useBookmarks() {
       );
       return { prev };
     },
-    onError: (_err, _vars, context) => {
+    onError: (err, _vars, context) => {
+      Sentry.captureException(err);
       if (context?.prev) queryClient.setQueryData(QUERY_KEY, context.prev);
       toast.error('Failed to add note');
     },
@@ -296,7 +310,8 @@ export function useBookmarks() {
       );
       return { prev };
     },
-    onError: (_err, _vars, context) => {
+    onError: (err, _vars, context) => {
+      Sentry.captureException(err);
       if (context?.prev) queryClient.setQueryData(QUERY_KEY, context.prev);
       toast.error('Failed to delete note');
     },
@@ -316,7 +331,8 @@ export function useBookmarks() {
       );
       return { prev };
     },
-    onError: (_err, _id, context) => {
+    onError: (err, _id, context) => {
+      Sentry.captureException(err);
       if (context?.prev) queryClient.setQueryData(QUERY_KEY, context.prev);
     },
     onSettled: () => queryClient.invalidateQueries({ queryKey: QUERY_KEY }),
@@ -335,7 +351,8 @@ export function useBookmarks() {
       );
       return { prev };
     },
-    onError: (_err, _vars, context) => {
+    onError: (err, _vars, context) => {
+      Sentry.captureException(err);
       if (context?.prev) queryClient.setQueryData(QUERY_KEY, context.prev);
       toast.error('Update failed');
     },

--- a/src/hooks/useFeedback.ts
+++ b/src/hooks/useFeedback.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import * as Sentry from '@sentry/react';
 import { useSupabase } from '../context/SupabaseProvider';
 import { useToast } from '../components/ui/Toast';
 import type { FeedbackItem, FeedbackInsert, FeedbackStatus } from '../types';
@@ -48,7 +49,10 @@ export function useFeedback() {
       void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
       toast.success('Feedback submitted');
     },
-    onError: () => toast.error('Failed to submit feedback'),
+    onError: (err) => {
+      Sentry.captureException(err);
+      toast.error('Failed to submit feedback');
+    },
   });
 
   const updateStatus = useMutation({
@@ -82,7 +86,8 @@ export function useFeedback() {
       );
       return { prev };
     },
-    onError: (_err, _vars, context) => {
+    onError: (err, _vars, context) => {
+      Sentry.captureException(err);
       if (context?.prev) queryClient.setQueryData(QUERY_KEY, context.prev);
       toast.error('Failed to update status');
     },

--- a/src/hooks/useTagAreas.ts
+++ b/src/hooks/useTagAreas.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import * as Sentry from '@sentry/react';
 import { useSupabase } from '../context/SupabaseProvider';
 import { useToast } from '../components/ui/Toast';
 import type { TagArea } from '../types';
@@ -49,7 +50,13 @@ export function useTagAreas() {
       );
       toast.success('Area created');
     },
-    onError: (err) => toast.error(err instanceof Error ? err.message : 'Failed to create area'),
+    onError: (err) => {
+      // Don't send expected client-side duplicate validation errors to Sentry
+      if (!(err instanceof Error && err.message.includes('already exists'))) {
+        Sentry.captureException(err);
+      }
+      toast.error(err instanceof Error ? err.message : 'Failed to create area');
+    },
   });
 
   const updateArea = useMutation({
@@ -71,7 +78,8 @@ export function useTagAreas() {
       );
       return { prev };
     },
-    onError: (_err, _vars, context) => {
+    onError: (err, _vars, context) => {
+      Sentry.captureException(err);
       if (context?.prev) queryClient.setQueryData(QUERY_KEY, context.prev);
       toast.error('Update failed');
     },
@@ -89,7 +97,8 @@ export function useTagAreas() {
       queryClient.setQueryData<TagArea[]>(QUERY_KEY, (old) => old?.filter((a) => a.id !== id));
       return { prev };
     },
-    onError: (_err, _id, context) => {
+    onError: (err, _id, context) => {
+      Sentry.captureException(err);
       if (context?.prev) queryClient.setQueryData(QUERY_KEY, context.prev);
       toast.error('Failed to delete area');
     },
@@ -121,7 +130,8 @@ export function useTagAreas() {
       });
       return { prev };
     },
-    onError: (_err, _vars, context) => {
+    onError: (err, _vars, context) => {
+      Sentry.captureException(err);
       if (context?.prev) queryClient.setQueryData(QUERY_KEY, context.prev);
       toast.error('Reorder failed');
     },

--- a/src/hooks/useTokens.ts
+++ b/src/hooks/useTokens.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import * as Sentry from '@sentry/react';
 import { useSupabase } from '../context/SupabaseProvider';
 import { useToast } from '../components/ui/Toast';
 import { generateToken, hashToken } from '../lib/tokens';
@@ -41,7 +42,10 @@ export function useTokens() {
       void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
       toast.success('Token created');
     },
-    onError: () => toast.error('Failed to create token'),
+    onError: (err) => {
+      Sentry.captureException(err);
+      toast.error('Failed to create token');
+    },
   });
 
   const deleteToken = useMutation({
@@ -55,7 +59,8 @@ export function useTokens() {
       queryClient.setQueryData<UserToken[]>(QUERY_KEY, (old) => old?.filter((t) => t.id !== id));
       return { prev };
     },
-    onError: (_err, _id, context) => {
+    onError: (err, _id, context) => {
+      Sentry.captureException(err);
       if (context?.prev) queryClient.setQueryData(QUERY_KEY, context.prev);
       toast.error('Failed to delete token');
     },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,6 +15,11 @@ Sentry.init({
   tracesSampleRate: 0.1,
 });
 
+// Catch unhandled promise rejections that Sentry's auto-capture misses in some browsers
+window.addEventListener('unhandledrejection', (event) => {
+  Sentry.captureException(event.reason);
+});
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {

--- a/supabase/functions/extract-content/index.ts
+++ b/supabase/functions/extract-content/index.ts
@@ -51,6 +51,7 @@ Deno.serve(async (req) => {
   } = await userClient.auth.getUser();
 
   if (authError || !user) {
+    console.error('extract-content: auth failed', { error: authError?.message });
     return jsonResponse({ error: 'Invalid or expired token' }, 401);
   }
 
@@ -75,11 +76,13 @@ Deno.serve(async (req) => {
     .single();
 
   if (fetchError || !bookmark) {
+    console.error('extract-content: bookmark not found', { bookmarkId, error: fetchError?.message });
     return jsonResponse({ error: 'Bookmark not found' }, 404);
   }
 
   // Verify ownership
   if (bookmark.user_id !== user.id) {
+    console.error('extract-content: ownership mismatch', { bookmarkId, userId: user.id });
     return jsonResponse({ error: 'Forbidden' }, 403);
   }
 
@@ -176,6 +179,7 @@ Deno.serve(async (req) => {
     );
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : 'Unknown error';
+    console.error('extract-content: extraction failed', { bookmarkId, url: bookmark.url, error: errorMessage });
 
     await adminClient
       .from('bookmarks')

--- a/supabase/functions/save-bookmark/index.ts
+++ b/supabase/functions/save-bookmark/index.ts
@@ -110,6 +110,7 @@ Deno.serve(async (req) => {
     .single();
 
   if (tokenError || !tokenRow) {
+    console.error('save-bookmark: token lookup failed', { tokenError: tokenError?.message });
     return jsonResponse({ error: 'Invalid token' }, 401);
   }
 
@@ -133,6 +134,7 @@ Deno.serve(async (req) => {
     .single();
 
   if (insertError) {
+    console.error('save-bookmark: insert failed', { url, userId: tokenRow.user_id, error: insertError.message });
     return jsonResponse({ error: 'Failed to save bookmark', detail: insertError.message }, 500);
   }
 


### PR DESCRIPTION
## Summary

Closes #25. Completes Sentry integration from partial (ErrorBoundary only) to full coverage across every error boundary in the app.

- **All 14 mutation `onError` callbacks** now call `Sentry.captureException(err)` alongside the existing toast — covers every DB/API failure in useBookmarks, useTagAreas, useTokens, useFeedback. Exception: expected client-side duplicate-area validation errors are filtered out.
- **Global `unhandledrejection` listener** in `main.tsx` — catches async promise rejections that Sentry's auto-capture misses in some browsers
- **Auth `getSession` fire-and-forget** — `.catch()` added so Supabase auth init failures are captured
- **`autoFetchMetadataAndTag` chain** — `.catch()` on the outer promise chain as a safety net
- **`save-bookmark` edge function** — `console.error` with context on token lookup failure and insert failure
- **`extract-content` edge function** — `console.error` with context on auth failure, bookmark not found, ownership mismatch, extraction failure

165 tests passing, 0 lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)