### PR TITLE
feat: export Obsidian tags as wikilinks (2.0.2)

### DIFF
--- a/src/lib/__tests__/obsidian.test.ts
+++ b/src/lib/__tests__/obsidian.test.ts
@@ -92,3 +92,26 @@ describe('generateMarkdown — book without URL', () => {
     expect(md).toContain('# Untitled Book');
   });
 });
+
+describe('generateMarkdown — wikilink tags', () => {
+  it('renders single tag as Obsidian wikilink', () => {
+    const md = generateMarkdown(makeBookmark({ tags: ['javascript'] }));
+    expect(md).toContain('tags: ["[[javascript]]"]');
+  });
+
+  it('renders multiple tags as wikilinks', () => {
+    const md = generateMarkdown(makeBookmark({ tags: ['react', 'typescript'] }));
+    expect(md).toContain('tags: ["[[react]]", "[[typescript]]"]');
+  });
+
+  it('escapes special chars inside wikilinks', () => {
+    const md = generateMarkdown(makeBookmark({ tags: ['c++', 'node"js'] }));
+    expect(md).toContain('"[[c++]]"');
+    expect(md).toContain('"[[node\\"js]]"');
+  });
+
+  it('omits tags line when tags array is empty', () => {
+    const md = generateMarkdown(makeBookmark({ tags: [] }));
+    expect(md).not.toContain('tags:');
+  });
+});

--- a/src/lib/obsidian.ts
+++ b/src/lib/obsidian.ts
@@ -26,7 +26,7 @@ export function generateMarkdown(bookmark: Bookmark): string {
   lines.push(`status: ${bookmark.status}`);
   if (bookmark.is_favorited) lines.push('favorited: true');
   if (bookmark.tags.length > 0) {
-    lines.push(`tags: [${bookmark.tags.map((t) => `"${yamlEscape(t)}"`).join(', ')}]`);
+    lines.push(`tags: [${bookmark.tags.map((t) => `"[[${yamlEscape(t)}]]"`).join(', ')}]`);
   }
   lines.push(`created: ${formatDate(bookmark.created_at)}`);
   if (bookmark.started_reading_at)


### PR DESCRIPTION
## Summary
- Wrap tags in `[[ ]]` in YAML frontmatter: `tags: ["[[javascript]]", "[[react]]"]`
- Valid YAML — Obsidian parses wikilinks inside double-quoted strings
- Enables backlink graph connections across exported notes in Obsidian

## Test plan
- [x] 4 new tests for wikilink format, escaping, and empty tags
- [x] All 169 existing tests pass
- [x] Quality pipeline: format → lint → typecheck → test → build

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)