### PR TITLE
feat: YouTube transcript extraction via captions (Phase 2 prerequisite)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,7 +84,7 @@ export default function App() {
               Skip to main content
             </a>
             {isDemo ? <DemoBanner onSignIn={handleExitDemo} /> : <UpdateBanner />}
-<Dashboard
+            <Dashboard
               userEmail={userEmail}
               onSignOut={isDemo ? handleExitDemo : handleSignOut}
               isDemo={isDemo}

--- a/src/hooks/__tests__/useBookmarks.test.ts
+++ b/src/hooks/__tests__/useBookmarks.test.ts
@@ -496,25 +496,47 @@ describe('triggerExtraction — invoke and invalidate', () => {
       ),
     );
   });
+});
 
-  it('skips functions.invoke for youtube source type', async () => {
-    vi.clearAllMocks();
-    mockSupabaseClient._resetBuilders();
+describe('useBookmarks — triggerExtraction (youtube transcript)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
+  function makeYouTubeRawBookmark(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'bm-yt',
+      url: 'https://youtube.com/watch?v=abc',
+      title: 'Test Video',
+      image: null,
+      excerpt: null,
+      source_type: 'youtube',
+      status: 'unread',
+      is_favorited: false,
+      notes: [],
+      tags: [],
+      metadata: {},
+      content: {},
+      content_status: 'pending',
+      content_fetched_at: null,
+      synced: false,
+      created_at: '2024-01-01T00:00:00Z',
+      status_changed_at: '2024-01-01T00:00:00Z',
+      started_reading_at: null,
+      finished_at: null,
+      bookmark_tags: [],
+      ...overrides,
+    };
+  }
+
+  it('calls functions.invoke for youtube (no longer in SKIP_EXTRACTION_SOURCES)', async () => {
     const builder = mockSupabaseClient._getBuilder('bookmarks');
     builder._resolve = { data: [], error: null };
 
     const { result } = renderHook(() => useBookmarks(), { wrapper: createWrapper() });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    builder._resolve = {
-      data: makeRawBookmark({
-        id: 'bm-yt',
-        url: 'https://youtube.com/watch?v=abc',
-        source_type: 'youtube',
-      }),
-      error: null,
-    };
+    builder._resolve = { data: makeYouTubeRawBookmark(), error: null };
 
     act(() => {
       result.current.addBookmark.mutate({ url: 'https://youtube.com/watch?v=abc' });
@@ -522,9 +544,12 @@ describe('triggerExtraction — invoke and invalidate', () => {
 
     await waitFor(() => expect(result.current.addBookmark.isSuccess).toBe(true));
 
-    // Wait a tick for any async fire-and-forget
-    await new Promise((r) => setTimeout(r, 50));
-    expect(mockSupabaseClient.functions.invoke).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(mockSupabaseClient.functions.invoke).toHaveBeenCalledWith(
+        'extract-content',
+        expect.objectContaining({ body: { bookmark_id: 'bm-yt' } }),
+      ),
+    );
   });
 });
 

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -493,7 +493,7 @@ export function useBookmarks() {
   }
 
   const isDemo = localStorage.getItem('contentdeck_demo') === 'true';
-  const SKIP_EXTRACTION_SOURCES = ['youtube', 'twitter', 'book', 'arxiv'];
+  const SKIP_EXTRACTION_SOURCES = ['twitter', 'book', 'arxiv'];
 
   async function triggerExtraction(bookmark: Bookmark) {
     if (isDemo) return;

--- a/supabase/functions/extract-content/index.ts
+++ b/supabase/functions/extract-content/index.ts
@@ -18,7 +18,68 @@ function jsonResponse(body: Record<string, unknown>, status: number) {
 const TEXT_CAP = 100 * 1024; // 100KB max text per bookmark
 const FETCH_TIMEOUT = 10_000; // 10s
 
-const SKIP_SOURCES = ['youtube', 'twitter', 'arxiv'];
+// Sources with no webpage text to extract via Readability
+// (YouTube now handled separately via caption extraction below)
+const SKIP_SOURCES = ['twitter', 'arxiv'];
+
+// ---- YouTube transcript helpers ----
+
+function extractYouTubeId(url: string): string | null {
+  const match = url.match(
+    /(?:youtube\.com\/(?:watch\?v=|shorts\/|embed\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/,
+  );
+  return match?.[1] ?? null;
+}
+
+async function fetchYouTubeTranscript(videoId: string): Promise<string | null> {
+  try {
+    // Fetch YouTube watch page to get caption track URLs
+    const pageRes = await fetch(`https://www.youtube.com/watch?v=${videoId}`, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+        'Accept-Language': 'en-US,en;q=0.9',
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT),
+    });
+    const html = await pageRes.text();
+
+    // Extract caption tracks JSON from ytInitialPlayerResponse
+    const match = html.match(/"captionTracks":(\[.*?\])/);
+    if (!match) return null;
+
+    const tracks = JSON.parse(match[1]) as Array<{ baseUrl: string; languageCode: string }>;
+    if (tracks.length === 0) return null;
+
+    // Prefer English, fall back to first available
+    const track =
+      tracks.find((t) => t.languageCode === 'en') ??
+      tracks.find((t) => t.languageCode?.startsWith('en')) ??
+      tracks[0];
+    if (!track?.baseUrl) return null;
+
+    // Fetch transcript in JSON3 format
+    const captionRes = await fetch(`${track.baseUrl}&fmt=json3`, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT),
+    });
+    const data = (await captionRes.json()) as {
+      events?: Array<{ segs?: Array<{ utf8?: string }> }>;
+    };
+
+    const text = (data.events ?? [])
+      .filter((e) => e.segs)
+      .map((e) => e.segs!.map((s) => s.utf8 ?? '').join(''))
+      .join(' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    // Return null if transcript is too short to be useful
+    if (text.length < 100) return null;
+    // Cap at 100KB
+    return text.length > TEXT_CAP ? text.slice(0, TEXT_CAP) : text;
+  } catch {
+    return null;
+  }
+}
 
 Deno.serve(async (req) => {
   // CORS preflight
@@ -76,7 +137,10 @@ Deno.serve(async (req) => {
     .single();
 
   if (fetchError || !bookmark) {
-    console.error('extract-content: bookmark not found', { bookmarkId, error: fetchError?.message });
+    console.error('extract-content: bookmark not found', {
+      bookmarkId,
+      error: fetchError?.message,
+    });
     return jsonResponse({ error: 'Bookmark not found' }, 404);
   }
 
@@ -86,7 +150,7 @@ Deno.serve(async (req) => {
     return jsonResponse({ error: 'Forbidden' }, 403);
   }
 
-  // Skip YouTube/Twitter — no article text to extract
+  // Skip sources with no extractable text (Twitter)
   if (SKIP_SOURCES.includes(bookmark.source_type)) {
     await adminClient
       .from('bookmarks')
@@ -94,6 +158,51 @@ Deno.serve(async (req) => {
       .eq('id', bookmarkId);
     return jsonResponse({ status: 'skipped', reason: 'Source type not extractable' }, 200);
   }
+
+  // ---- YouTube transcript extraction ----
+  if (bookmark.source_type === 'youtube') {
+    const videoId = extractYouTubeId(bookmark.url);
+    if (!videoId) {
+      await adminClient
+        .from('bookmarks')
+        .update({ content_status: 'skipped' })
+        .eq('id', bookmarkId);
+      return jsonResponse({ status: 'skipped', reason: 'Could not extract video ID' }, 200);
+    }
+
+    await adminClient
+      .from('bookmarks')
+      .update({ content_status: 'extracting' })
+      .eq('id', bookmarkId);
+
+    const transcript = await fetchYouTubeTranscript(videoId);
+    if (!transcript) {
+      await adminClient
+        .from('bookmarks')
+        .update({ content_status: 'skipped' })
+        .eq('id', bookmarkId);
+      return jsonResponse({ status: 'skipped', reason: 'No captions available' }, 200);
+    }
+
+    const wordCount = transcript.split(/\s+/).filter(Boolean).length;
+    await adminClient
+      .from('bookmarks')
+      .update({
+        content: {
+          text: transcript,
+          method: 'youtube_captions',
+          word_count: wordCount,
+          extracted_at: new Date().toISOString(),
+        },
+        content_status: 'success',
+        content_fetched_at: new Date().toISOString(),
+      })
+      .eq('id', bookmarkId);
+
+    return jsonResponse({ status: 'success', word_count: wordCount }, 200);
+  }
+
+  // ---- Readability extraction (all other sources) ----
 
   // Set status to extracting
   await adminClient
@@ -179,7 +288,11 @@ Deno.serve(async (req) => {
     );
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : 'Unknown error';
-    console.error('extract-content: extraction failed', { bookmarkId, url: bookmark.url, error: errorMessage });
+    console.error('extract-content: extraction failed', {
+      bookmarkId,
+      url: bookmark.url,
+      error: errorMessage,
+    });
 
     await adminClient
       .from('bookmarks')


### PR DESCRIPTION
## Summary
- `extract-content` edge function now extracts YouTube transcripts via caption API
- Fetches `ytInitialPlayerResponse` from watch page to get caption track URLs
- Prefers English, falls back to first available track
- Stores transcript in `content.text` with `method: 'youtube_captions'`
- Videos without captions → `content_status: 'skipped'` (not an error)
- Private/age-restricted videos → same graceful degradation
- `SKIP_EXTRACTION_SOURCES` no longer includes `'youtube'` — triggers extraction on add

## Why
YouTube transcripts give Phase 2 Smart Connections and Chat with Library parity with articles/papers.

## Test plan
- [x] 1 new test: youtube bookmark triggers `functions.invoke` (extraction no longer skipped)
- [x] 166 tests pass, build clean
- [x] Quality pipeline: format → lint → typecheck → test → build
- [ ] Manual: add YouTube video with captions → wait → check `content_status: 'success'` and `content.text` in Supabase dashboard
- [ ] Edge function must be redeployed: `npx supabase functions deploy extract-content --no-verify-jwt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)