### PR TITLE
fix: arXiv title parsing, iOS input zoom, mobile stats button

### DIFF
--- a/docs/log/v3.3.1-maintenance-fixes.md
+++ b/docs/log/v3.3.1-maintenance-fixes.md
@@ -1,0 +1,56 @@
+# v3.3.1 — Maintenance Fixes
+
+**Date:** 2026-02-28
+**Branch:** `fix/34-33-7-maintenance-fixes`
+**Issues:** Closes #34, #33, #7
+
+## Summary
+
+Three bug fixes from the open GitHub issues backlog.
+
+---
+
+## Fix #34 — arXiv title/metadata not populating
+
+**Root cause:** `fetchArxivMetadata` in `src/lib/metadata.ts` used `DOMParser` + `querySelector()` on Atom-namespaced XML. In browsers, `querySelector('entry')` returns `null` for elements under a default XML namespace (`xmlns="http://www.w3.org/2005/Atom"`), so the function always returned `{}`.
+
+**Secondary bug:** The arXiv `content.text` (abstract) write in `useBookmarks.ts` was nested inside `if (updates)`. If the bookmark already had a title, `updates` was `null` and the abstract was never stored.
+
+**Changes:**
+- `src/lib/metadata.ts` — replaced all `querySelector`/`querySelectorAll` calls with `getElementsByTagName`, which is namespace-agnostic
+- `src/hooks/useBookmarks.ts` — moved arXiv `content.text` write outside the `if (updates)` block so it fires unconditionally when an abstract is returned
+- `src/lib/__tests__/metadata.test.ts` — added namespace robustness test verifying `getElementsByTagName` works on Atom XML with an extra namespace declaration (`xmlns:arxiv=...`)
+
+---
+
+## Fix #33 — iOS Safari zooms on input focus
+
+**Root cause:** iOS Safari zooms when any focusable input/select/textarea has `font-size < 16px`. Six elements across four files used `text-sm` (14px).
+
+**Changes:** Replaced `text-sm` → `text-base` (16px) on all `<input>`, `<textarea>`, and `<select>` elements in:
+- `src/components/feed/SearchBar.tsx`
+- `src/components/detail/NoteComposer.tsx`
+- `src/components/modals/FeedbackModal.tsx` (title input, description textarea, severity select)
+- `src/components/modals/SettingsModal.tsx` (AI key, YouTube key, Obsidian vault inputs)
+
+Labels, help text, and buttons retain `text-sm`.
+
+---
+
+## Fix #7 — Stats modal unreachable on mobile
+
+**Root cause:** `AppShell.tsx` passed `onStats` to `Sidebar` but not to `MobileHeader`. `MobileHeader` had no `onStats` prop, so the stats modal was completely unreachable on mobile.
+
+**Changes:**
+- `src/components/layout/MobileHeader.tsx` — added `onStats: () => void` prop; added `BarChart3` button between Settings and Feedback; imported `BarChart3` from lucide-react
+- `src/components/layout/AppShell.tsx` — threaded `onStats={onStats}` to `MobileHeader`
+
+---
+
+## SW Cache
+
+Bumped `CACHE_NAME` from `contentdeck-v3.1.0` → `contentdeck-v3.3.1` in `public/sw.js`.
+
+## Test Count
+
+180 tests passing (was 179 — +1 arXiv namespace test).

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'contentdeck-v3.1.0'
+const CACHE_NAME = 'contentdeck-v3.3.1'
 
 self.addEventListener('install', () => {
   self.skipWaiting() // Auto-activate immediately — personal tool, seamless updates desired

--- a/src/components/detail/NoteComposer.tsx
+++ b/src/components/detail/NoteComposer.tsx
@@ -71,7 +71,7 @@ export default function NoteComposer({ onAddNote, isPending }: NoteComposerProps
         onKeyDown={handleKeyDown}
         placeholder="Type your thought..."
         rows={2}
-        className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-sm text-surface-900 dark:text-surface-100 placeholder:text-surface-400 resize-none min-h-[60px]"
+        className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-base text-surface-900 dark:text-surface-100 placeholder:text-surface-400 resize-none min-h-[60px]"
       />
 
       {/* Submit */}

--- a/src/components/feed/SearchBar.tsx
+++ b/src/components/feed/SearchBar.tsx
@@ -53,7 +53,7 @@ const SearchBar = forwardRef<SearchBarHandle, { autoFocus?: boolean }>(function 
         onChange={(e) => setLocalValue(e.target.value)}
         placeholder="Search bookmarks..."
         aria-label="Search bookmarks"
-        className="w-full pl-9 pr-8 py-2 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-sm text-surface-900 dark:text-surface-100 placeholder:text-surface-400 min-h-[40px]"
+        className="w-full pl-9 pr-8 py-2 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-base text-surface-900 dark:text-surface-100 placeholder:text-surface-400 min-h-[40px]"
       />
       {localValue && (
         <button

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -44,6 +44,7 @@ export default function AppShell({
           onAdd={onAdd}
           onToggleSearch={onToggleSearch}
           onSettings={onSettings}
+          onStats={onStats}
           onFeedback={onFeedback}
           showSearch={showSearch}
         />

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -1,10 +1,20 @@
-import { Search, Sun, Moon, BookOpen, Plus, Settings, MessageSquare } from 'lucide-react';
+import {
+  Search,
+  Sun,
+  Moon,
+  BookOpen,
+  Plus,
+  Settings,
+  MessageSquare,
+  BarChart3,
+} from 'lucide-react';
 import { useTheme } from '../../hooks/useTheme';
 
 interface MobileHeaderProps {
   onAdd: () => void;
   onToggleSearch: () => void;
   onSettings: () => void;
+  onStats: () => void;
   onFeedback: () => void;
   showSearch: boolean;
 }
@@ -13,6 +23,7 @@ export default function MobileHeader({
   onAdd,
   onToggleSearch,
   onSettings,
+  onStats,
   onFeedback,
 }: MobileHeaderProps) {
   const { toggleTheme, theme } = useTheme();
@@ -37,6 +48,13 @@ export default function MobileHeader({
           aria-label="Settings"
         >
           <Settings size={20} className="text-surface-600 dark:text-surface-400" />
+        </button>
+        <button
+          onClick={onStats}
+          className="p-2.5 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800 min-w-[44px] min-h-[44px] flex items-center justify-center"
+          aria-label="View statistics"
+        >
+          <BarChart3 size={20} className="text-surface-600 dark:text-surface-400" />
         </button>
         <button
           onClick={onFeedback}

--- a/src/components/modals/FeedbackModal.tsx
+++ b/src/components/modals/FeedbackModal.tsx
@@ -141,7 +141,7 @@ export default function FeedbackModal({ open, onClose, activeBookmark }: Feedbac
                 id="feedback-severity"
                 value={severity}
                 onChange={(e) => setSeverity(e.target.value as FeedbackSeverity)}
-                className="w-full px-3 py-2 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 text-sm min-h-[44px]"
+                className="w-full px-3 py-2 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 text-base min-h-[44px]"
               >
                 <option value="blocking">Blocking — can't use the app</option>
                 <option value="major">Major — significant impact</option>
@@ -169,7 +169,7 @@ export default function FeedbackModal({ open, onClose, activeBookmark }: Feedbac
               placeholder={
                 feedbackType === 'bug' ? 'Describe the bug briefly' : 'What would you like?'
               }
-              className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 text-sm min-h-[44px]"
+              className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 text-base min-h-[44px]"
             />
           </div>
 
@@ -187,7 +187,7 @@ export default function FeedbackModal({ open, onClose, activeBookmark }: Feedbac
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Steps to reproduce, expected vs actual behaviour, etc."
-              className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 text-sm resize-none"
+              className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 text-base resize-none"
             />
           </div>
 

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -189,7 +189,7 @@ export default function SettingsModal({
                   value={aiKey}
                   onChange={(e) => setAiKey(e.target.value)}
                   placeholder="sk-or-..."
-                  className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 text-sm min-h-[44px]"
+                  className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 text-base min-h-[44px]"
                 />
               </div>
               <div>
@@ -206,7 +206,7 @@ export default function SettingsModal({
                   value={ytKey}
                   onChange={(e) => setYtKey(e.target.value)}
                   placeholder="AIza..."
-                  className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 text-sm min-h-[44px]"
+                  className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 text-base min-h-[44px]"
                 />
               </div>
             </div>
@@ -230,7 +230,7 @@ export default function SettingsModal({
                 value={obsidianVault}
                 onChange={(e) => setObsidianVault(e.target.value)}
                 placeholder="ContentDeck"
-                className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 text-sm min-h-[44px]"
+                className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 text-base min-h-[44px]"
               />
             </div>
           </section>

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -436,24 +436,25 @@ export function useBookmarks() {
               .getQueryData<Bookmark[]>(QUERY_KEY)
               ?.find((b) => b.id === bookmark.id) ?? bookmark),
           };
-          // For arXiv, also populate content.text with the abstract for future RAG use
-          if (bookmark.source_type === 'arxiv' && result.metadata?.abstract) {
-            const text = result.metadata.abstract;
-            void db
-              .from('bookmarks')
-              .update({
-                content: {
-                  text,
-                  method: 'arxiv_api',
-                  word_count: text.split(/\s+/).filter(Boolean).length,
-                  extracted_at: new Date().toISOString(),
-                },
-                content_status: 'success',
-                content_fetched_at: new Date().toISOString(),
-              })
-              .eq('id', bookmark.id);
-          }
         }
+      }
+      // For arXiv, populate content.text with the abstract regardless of whether
+      // other metadata fields needed updating — abstract should always be stored.
+      if (bookmark.source_type === 'arxiv' && result.metadata?.abstract) {
+        const text = result.metadata.abstract;
+        void db
+          .from('bookmarks')
+          .update({
+            content: {
+              text,
+              method: 'arxiv_api',
+              word_count: text.split(/\s+/).filter(Boolean).length,
+              extracted_at: new Date().toISOString(),
+            },
+            content_status: 'success',
+            content_fetched_at: new Date().toISOString(),
+          })
+          .eq('id', bookmark.id);
       }
     } catch (err) {
       // Silent fail for metadata — still attempt tagging with whatever we have

--- a/src/lib/__tests__/metadata.test.ts
+++ b/src/lib/__tests__/metadata.test.ts
@@ -286,6 +286,30 @@ describe('fetchMetadata — arXiv', () => {
     expect(calledUrl).toContain('export.arxiv.org/api/query');
     expect(calledUrl).toContain('1706.03762');
   });
+
+  it('parses title and authors from Atom XML with default namespace (getElementsByTagName)', async () => {
+    // Verifies that the namespace-safe getElementsByTagName approach works on
+    // XML where querySelector('entry') would return null in browsers due to
+    // the default Atom namespace (xmlns="http://www.w3.org/2005/Atom").
+    const namespacedXml = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <id>http://arxiv.org/abs/2301.00001v1</id>
+    <title>Namespace Test Paper</title>
+    <summary>An abstract about namespace handling.</summary>
+    <published>2023-01-01T00:00:00Z</published>
+    <author><name>Alice Example</name></author>
+  </entry>
+</feed>`;
+    mockFetch.mockResolvedValueOnce(xmlResponse(namespacedXml));
+
+    const result = await fetchMetadata('https://arxiv.org/abs/2301.00001', 'arxiv');
+
+    expect(result.title).toBe('Namespace Test Paper');
+    expect(result.metadata?.authors).toEqual(['Alice Example']);
+    expect(result.metadata?.abstract).toBe('An abstract about namespace handling.');
+    expect(result.metadata?.published).toBe('2023-01-01');
+  });
 });
 
 describe('fetchMetadata — routing', () => {

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -183,14 +183,19 @@ async function fetchArxivMetadata(url: string): Promise<MetadataResult> {
 
     const parser = new DOMParser();
     const doc = parser.parseFromString(xml, 'application/xml');
-    const entry = doc.querySelector('entry');
+    // getElementsByTagName is used instead of querySelector because Atom XML has a default
+    // namespace (xmlns="http://www.w3.org/2005/Atom") which makes querySelector unreliable
+    // in browsers — it returns null for namespace-qualified elements.
+    const entry = doc.getElementsByTagName('entry')[0];
     if (!entry) return {};
 
-    const rawTitle = entry.querySelector('title')?.textContent?.trim() ?? '';
+    const rawTitle = entry.getElementsByTagName('title')[0]?.textContent?.trim() ?? '';
     const title = rawTitle.replace(/\s+/g, ' ');
-    const abstract = entry.querySelector('summary')?.textContent?.trim().replace(/\s+/g, ' ') ?? '';
-    const published = entry.querySelector('published')?.textContent?.slice(0, 10) ?? undefined;
-    const authors = Array.from(entry.querySelectorAll('author > name')).map(
+    const abstract =
+      entry.getElementsByTagName('summary')[0]?.textContent?.trim().replace(/\s+/g, ' ') ?? '';
+    const published =
+      entry.getElementsByTagName('published')[0]?.textContent?.slice(0, 10) ?? undefined;
+    const authors = Array.from(entry.getElementsByTagName('name')).map(
       (n) => n.textContent?.trim() ?? '',
     );
 


### PR DESCRIPTION
## Summary

- **#34 arXiv title not loading** — `querySelector` fails on Atom-namespaced XML in browsers (returns `null`); replaced with `getElementsByTagName` throughout `fetchArxivMetadata`. Also moved arXiv `content.text` (abstract) write outside `if (updates)` so it fires even when the bookmark already has a title.
- **#33 iOS Safari zoom on input focus** — iOS zooms when `font-size < 16px`; changed `text-sm` → `text-base` on all 6 inputs/textareas/selects across SearchBar, NoteComposer, FeedbackModal, SettingsModal.
- **#7 Stats modal unreachable on mobile** — `onStats` was threaded to Sidebar but never to MobileHeader; added `onStats` prop + BarChart3 button to MobileHeader, wired from AppShell.

## Test plan
- [ ] Add an arXiv bookmark (`arxiv.org/abs/...`) → title, authors, and abstract should populate within ~10s
- [ ] Focus each input on iOS Safari → no zoom
- [ ] Mobile: tap new BarChart3 button in header → Stats modal opens
- [ ] 180 Vitest tests passing

Closes #34, #33, #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)