### PR TITLE
feat: enhanced Obsidian export — areas, auto-export, batch, reflection

### DIFF
--- a/docs/log/v3.4-obsidian-export-phase-a.md
+++ b/docs/log/v3.4-obsidian-export-phase-a.md
@@ -1,0 +1,73 @@
+# v3.4 — Obsidian Export Phase A
+
+**Date:** 2026-03-01
+**Branch:** `feat/obsidian-integration-phase-a`
+**PR:** closes #TBD
+
+## What shipped
+
+Phase A of the Obsidian integration — improved frontmatter, auto-export, and batch export. Closes the Reflect → Export loop so processed bookmarks land permanently in Obsidian.
+
+### `src/lib/obsidian.ts`
+
+1. **`areas` in frontmatter** — Area names exported as `[[wikilinks]]`, enabling Dataview queries and knowledge graph connections by area.
+2. **`content_deck_id` in frontmatter** — Bookmark UUID added as a sync anchor for future bidirectional sync.
+3. **Reflection notes separate section** — Notes with `type: 'reflection'` now render under `## Reflection` instead of `## Notes`. Regular notes unaffected.
+4. **arXiv abstract section** — arXiv bookmarks use `## Abstract` header and full `metadata.abstract` text (not the short `excerpt`). Falls back to excerpt if abstract unavailable.
+5. **Fix URI navigation** — `window.location.href = uri` → `window.open(uri)` so ContentDeck tab stays open when Obsidian opens.
+
+### `src/types/index.ts`
+
+- Added `'reflection'` to `NoteType` union type.
+
+### `src/components/detail/NoteCard.tsx`
+
+- Added `reflection` config to `NOTE_CONFIG` (purple theme, mirror emoji).
+
+### `src/hooks/useBookmarks.ts`
+
+- **Auto-export on mark done** — `cycleStatus` `onSuccess` checks `obsidian_vault` and `obsidian_auto_export` localStorage keys. If set, calls `exportToObsidianUri` and `markSynced` silently.
+- Import: `exportToObsidianUri` from `../lib/obsidian`.
+
+### `src/components/modals/SettingsModal.tsx`
+
+- **Auto-export toggle** — shown only when vault name is set. Persists to `obsidian_auto_export` localStorage key.
+- **Batch export button** — shows count of done+unsynced bookmarks. Calls `batchExport` with progress callback. Labels: "Export All Done" (Chrome/desktop with File System Access API) or "Copy All Done as Markdown" (Safari/iOS fallback). Marks all exported bookmarks as synced.
+
+## Tests
+
+10 new test cases in `src/lib/__tests__/obsidian.test.ts`:
+- `content_deck_id` in frontmatter
+- `areas` wikilinks in frontmatter
+- `areas` line omitted when empty
+- Reflection note appears under `## Reflection`
+- Reflection note absent from `## Notes`
+- Regular + reflection notes in separate sections (order verified)
+- arXiv: `## Abstract` header used
+- arXiv: full abstract text (not excerpt) used
+- arXiv: falls back to excerpt when no abstract
+- Non-arXiv: `## Summary` header used
+
+**Total tests: 190** (was 180)
+
+## Recommended Obsidian workflows enabled
+
+With Dataview plugin installed:
+```dataview
+TABLE title, channel
+FROM "ContentDeck/Videos"
+WHERE contains(areas, "[[AI]]")
+SORT finished DESC
+```
+
+```dataview
+CALENDAR finished
+FROM "ContentDeck"
+WHERE finished >= date(today) - dur(30 days)
+```
+
+## What's next
+
+- Phase B: standalone Obsidian community plugin (separate repo) — two-way sync via `content_deck_id`
+- Phase 2.3: New Home Screen (scoring engine feed)
+- Phase 2.4: Post-Read Reflection Prompt (voice via Web Speech API + text)

--- a/src/components/detail/NoteCard.tsx
+++ b/src/components/detail/NoteCard.tsx
@@ -34,6 +34,12 @@ const NOTE_CONFIG: Record<NoteType, { emoji: string; label: string; color: strin
     color: 'text-indigo-600 dark:text-indigo-400',
     bg: 'bg-indigo-500/10 border-indigo-500/20',
   },
+  reflection: {
+    emoji: '🪞',
+    label: 'Reflection',
+    color: 'text-purple-600 dark:text-purple-400',
+    bg: 'bg-purple-500/10 border-purple-500/20',
+  },
 };
 
 export default function NoteCard({ type, content, createdAt, onDelete }: NoteCardProps) {

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
 import { ExternalLink, Smartphone, FlaskConical, Sun, Moon, BookOpen, Anchor } from 'lucide-react';
 import { useTheme } from '../../hooks/useTheme';
+import { useBookmarks } from '../../hooks/useBookmarks';
+import { batchExport } from '../../lib/obsidian';
 import Modal from '../ui/Modal';
 import Button from '../ui/Button';
 import TokenManager from '../settings/TokenManager';
@@ -28,6 +30,16 @@ export default function SettingsModal({
   const [obsidianVault, setObsidianVault] = useState(
     () => localStorage.getItem('obsidian_vault') ?? '',
   );
+  const [autoExport, setAutoExport] = useState(
+    () => localStorage.getItem('obsidian_auto_export') === 'true',
+  );
+  const [exportProgress, setExportProgress] = useState<{ current: number; total: number } | null>(
+    null,
+  );
+
+  const { bookmarks, markSynced } = useBookmarks();
+  const doneUnsynced = bookmarks.filter((b) => b.status === 'done' && !b.synced);
+  const hasDirectoryPicker = 'showDirectoryPicker' in window;
 
   // Save keys to localStorage on change
   useEffect(() => {
@@ -44,6 +56,11 @@ export default function SettingsModal({
     if (obsidianVault) localStorage.setItem('obsidian_vault', obsidianVault);
     else localStorage.removeItem('obsidian_vault');
   }, [obsidianVault]);
+
+  useEffect(() => {
+    if (autoExport) localStorage.setItem('obsidian_auto_export', 'true');
+    else localStorage.removeItem('obsidian_auto_export');
+  }, [autoExport]);
 
   return (
     <Modal open={open} onClose={onClose} title="Settings" size="md">
@@ -217,21 +234,71 @@ export default function SettingsModal({
             <h3 className="text-sm font-semibold text-surface-900 dark:text-surface-100 mb-2">
               Obsidian Export
             </h3>
-            <div>
-              <label
-                htmlFor="settings-vault"
-                className="block text-xs text-surface-500 dark:text-surface-400 mb-1"
-              >
-                Vault Folder Name <span className="text-surface-400">(e.g. ContentDeck)</span>
-              </label>
-              <input
-                id="settings-vault"
-                type="text"
-                value={obsidianVault}
-                onChange={(e) => setObsidianVault(e.target.value)}
-                placeholder="ContentDeck"
-                className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 text-base min-h-[44px]"
-              />
+            <div className="space-y-3">
+              <div>
+                <label
+                  htmlFor="settings-vault"
+                  className="block text-xs text-surface-500 dark:text-surface-400 mb-1"
+                >
+                  Vault Folder Name <span className="text-surface-400">(e.g. ContentDeck)</span>
+                </label>
+                <input
+                  id="settings-vault"
+                  type="text"
+                  value={obsidianVault}
+                  onChange={(e) => setObsidianVault(e.target.value)}
+                  placeholder="ContentDeck"
+                  className="w-full px-3 py-2.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-900 dark:text-surface-100 placeholder:text-surface-400 text-base min-h-[44px]"
+                />
+              </div>
+
+              {obsidianVault && (
+                <>
+                  <label className="flex items-center gap-3 cursor-pointer min-h-[44px]">
+                    <input
+                      type="checkbox"
+                      checked={autoExport}
+                      onChange={(e) => setAutoExport(e.target.checked)}
+                      className="w-4 h-4 rounded accent-primary-600"
+                    />
+                    <span className="text-xs text-surface-700 dark:text-surface-300">
+                      Auto-export to Obsidian when marking done
+                    </span>
+                  </label>
+
+                  <div className="space-y-1.5">
+                    {doneUnsynced.length > 0 && (
+                      <p className="text-xs text-surface-500 dark:text-surface-400">
+                        {doneUnsynced.length} item{doneUnsynced.length !== 1 ? 's' : ''} done, not
+                        yet synced
+                      </p>
+                    )}
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      disabled={doneUnsynced.length === 0 || exportProgress !== null}
+                      onClick={async () => {
+                        setExportProgress({ current: 0, total: doneUnsynced.length });
+                        const result = await batchExport(
+                          doneUnsynced,
+                          obsidianVault,
+                          (current, total) => setExportProgress({ current, total }),
+                        );
+                        setExportProgress(null);
+                        if (result.exported > 0) {
+                          for (const b of doneUnsynced) markSynced.mutate(b.id);
+                        }
+                      }}
+                    >
+                      {exportProgress
+                        ? `Exporting ${exportProgress.current}/${exportProgress.total}...`
+                        : hasDirectoryPicker
+                          ? 'Export All Done'
+                          : 'Copy All Done as Markdown'}
+                    </Button>
+                  </div>
+                </>
+              )}
             </div>
           </section>
 

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -4,6 +4,7 @@ import { useSupabase } from '../context/SupabaseProvider';
 import { useToast } from '../components/ui/Toast';
 import { fetchMetadata } from '../lib/metadata';
 import { suggestTags } from '../lib/ai';
+import { exportToObsidianUri } from '../lib/obsidian';
 import { detectSourceType, isBookWithoutUrl } from '../lib/utils';
 import type { Bookmark, TagArea, Status, NoteType, Note, BookmarkMetadata } from '../types';
 
@@ -155,6 +156,22 @@ export function useBookmarks() {
         old?.map((b) => (b.id === id ? { ...b, status: newStatus } : b)),
       );
       return { prev };
+    },
+    onSuccess: (_data, { id, newStatus }) => {
+      if (
+        newStatus === 'done' &&
+        localStorage.getItem('obsidian_vault') &&
+        localStorage.getItem('obsidian_auto_export') === 'true'
+      ) {
+        const vaultName = localStorage.getItem('obsidian_vault')!;
+        const updatedBookmark = queryClient
+          .getQueryData<Bookmark[]>(QUERY_KEY)
+          ?.find((b) => b.id === id);
+        if (updatedBookmark) {
+          exportToObsidianUri(updatedBookmark, vaultName);
+          markSynced.mutate(id);
+        }
+      }
     },
     onError: (err, _vars, context) => {
       Sentry.captureException(err);

--- a/src/lib/__tests__/obsidian.test.ts
+++ b/src/lib/__tests__/obsidian.test.ts
@@ -115,3 +115,129 @@ describe('generateMarkdown — wikilink tags', () => {
     expect(md).not.toContain('tags:');
   });
 });
+
+describe('generateMarkdown — areas and content_deck_id', () => {
+  it('includes content_deck_id in frontmatter', () => {
+    const md = generateMarkdown(makeBookmark({ id: 'abc-123' }));
+    expect(md).toContain('content_deck_id: "abc-123"');
+  });
+
+  it('renders areas as Obsidian wikilinks', () => {
+    const md = generateMarkdown(
+      makeBookmark({
+        areas: [
+          {
+            id: 'a1',
+            name: 'AI',
+            description: null,
+            color: null,
+            emoji: null,
+            sort_order: 0,
+            created_at: '2024-01-01T00:00:00Z',
+          },
+          {
+            id: 'a2',
+            name: 'Product',
+            description: null,
+            color: null,
+            emoji: null,
+            sort_order: 1,
+            created_at: '2024-01-01T00:00:00Z',
+          },
+        ],
+      }),
+    );
+    expect(md).toContain('areas: ["[[AI]]", "[[Product]]"]');
+  });
+
+  it('omits areas line when areas array is empty', () => {
+    const md = generateMarkdown(makeBookmark({ areas: [] }));
+    expect(md).not.toContain('areas:');
+  });
+});
+
+describe('generateMarkdown — reflection notes', () => {
+  it('renders reflection note under ## Reflection section', () => {
+    const md = generateMarkdown(
+      makeBookmark({
+        notes: [
+          { type: 'reflection', content: 'Key takeaway here', created_at: '2024-01-15T10:00:00Z' },
+        ],
+      }),
+    );
+    expect(md).toContain('## Reflection');
+    expect(md).toContain('Key takeaway here');
+  });
+
+  it('does not include reflection note under ## Notes section', () => {
+    const md = generateMarkdown(
+      makeBookmark({
+        notes: [
+          { type: 'reflection', content: 'My reflection', created_at: '2024-01-15T10:00:00Z' },
+        ],
+      }),
+    );
+    expect(md).not.toContain('## Notes');
+  });
+
+  it('renders regular and reflection notes in separate sections', () => {
+    const md = generateMarkdown(
+      makeBookmark({
+        notes: [
+          { type: 'insight', content: 'An insight', created_at: '2024-01-15T10:00:00Z' },
+          { type: 'reflection', content: 'A reflection', created_at: '2024-01-15T11:00:00Z' },
+        ],
+      }),
+    );
+    expect(md).toContain('## Notes');
+    expect(md).toContain('An insight');
+    expect(md).toContain('## Reflection');
+    expect(md).toContain('A reflection');
+    // Reflection section comes after Notes section
+    expect(md.indexOf('## Reflection')).toBeGreaterThan(md.indexOf('## Notes'));
+  });
+});
+
+describe('generateMarkdown — arXiv abstract', () => {
+  it('uses ## Abstract header for arXiv source type', () => {
+    const md = generateMarkdown(
+      makeBookmark({
+        source_type: 'arxiv',
+        excerpt: 'Short excerpt',
+        metadata: { abstract: 'Full abstract text here' },
+      }),
+    );
+    expect(md).toContain('## Abstract');
+    expect(md).not.toContain('## Summary');
+  });
+
+  it('uses full abstract text (not excerpt) for arXiv', () => {
+    const md = generateMarkdown(
+      makeBookmark({
+        source_type: 'arxiv',
+        excerpt: 'Short excerpt',
+        metadata: { abstract: 'Full abstract text here' },
+      }),
+    );
+    expect(md).toContain('Full abstract text here');
+    expect(md).not.toContain('Short excerpt');
+  });
+
+  it('falls back to excerpt for arXiv when no abstract in metadata', () => {
+    const md = generateMarkdown(
+      makeBookmark({
+        source_type: 'arxiv',
+        excerpt: 'Fallback excerpt',
+        metadata: {},
+      }),
+    );
+    expect(md).toContain('## Abstract');
+    expect(md).toContain('Fallback excerpt');
+  });
+
+  it('uses ## Summary header for non-arXiv source types', () => {
+    const md = generateMarkdown(makeBookmark({ source_type: 'blog', excerpt: 'Blog excerpt' }));
+    expect(md).toContain('## Summary');
+    expect(md).not.toContain('## Abstract');
+  });
+});

--- a/src/lib/obsidian.ts
+++ b/src/lib/obsidian.ts
@@ -24,7 +24,11 @@ export function generateMarkdown(bookmark: Bookmark): string {
   if (bookmark.title) lines.push(`title: "${yamlEscape(bookmark.title)}"`);
   lines.push(`source: ${SOURCE_LABELS[bookmark.source_type]}`);
   lines.push(`status: ${bookmark.status}`);
+  lines.push(`content_deck_id: "${bookmark.id}"`);
   if (bookmark.is_favorited) lines.push('favorited: true');
+  if (bookmark.areas.length > 0) {
+    lines.push(`areas: [${bookmark.areas.map((a) => `"[[${yamlEscape(a.name)}]]"`).join(', ')}]`);
+  }
   if (bookmark.tags.length > 0) {
     lines.push(`tags: [${bookmark.tags.map((t) => `"[[${yamlEscape(t)}]]"`).join(', ')}]`);
   }
@@ -55,23 +59,45 @@ export function generateMarkdown(bookmark: Bookmark): string {
     lines.push('');
   }
 
-  // Excerpt
-  if (bookmark.excerpt) {
-    lines.push('## Summary');
+  // Summary / Abstract
+  const isArxiv = bookmark.source_type === 'arxiv';
+  const summaryText = isArxiv
+    ? (bookmark.metadata?.abstract ?? bookmark.excerpt)
+    : bookmark.excerpt;
+  if (summaryText) {
+    lines.push(`## ${isArxiv ? 'Abstract' : 'Summary'}`);
     lines.push('');
-    lines.push(bookmark.excerpt);
+    lines.push(summaryText);
     lines.push('');
   }
 
-  // Notes
-  if (bookmark.notes.length > 0) {
+  // Notes (non-reflection)
+  const regularNotes = bookmark.notes.filter((n) => n.type !== 'reflection');
+  const reflections = bookmark.notes.filter((n) => n.type === 'reflection');
+
+  if (regularNotes.length > 0) {
     lines.push('## Notes');
     lines.push('');
-    for (const note of bookmark.notes) {
-      const emoji = { insight: '💡', question: '❓', highlight: '🖍️', note: '📝' }[note.type];
+    for (const note of regularNotes) {
+      const emoji =
+        { insight: '💡', question: '❓', highlight: '🖍️', note: '📝' }[
+          note.type as 'insight' | 'question' | 'highlight' | 'note'
+        ] ?? '📝';
       const label = note.type.charAt(0).toUpperCase() + note.type.slice(1);
       lines.push(`### ${emoji} ${label}`);
       lines.push('');
+      lines.push(note.content);
+      lines.push('');
+      lines.push(`*${formatDate(note.created_at)}*`);
+      lines.push('');
+    }
+  }
+
+  // Reflection notes
+  if (reflections.length > 0) {
+    lines.push('## Reflection');
+    lines.push('');
+    for (const note of reflections) {
       lines.push(note.content);
       lines.push('');
       lines.push(`*${formatDate(note.created_at)}*`);
@@ -135,7 +161,7 @@ export function exportToObsidianUri(bookmark: Bookmark, vaultName: string): bool
   const content = encodeURIComponent(generateMarkdown(bookmark));
   const uri = `obsidian://new?vault=${encodeURIComponent(vaultName)}&file=${encodeURIComponent(filePath)}&content=${content}`;
 
-  window.location.href = uri;
+  window.open(uri);
   return true;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,7 +7,7 @@ export type SourceType =
   | 'book'
   | 'arxiv';
 export type Status = 'unread' | 'reading' | 'done';
-export type NoteType = 'insight' | 'question' | 'highlight' | 'note';
+export type NoteType = 'insight' | 'question' | 'highlight' | 'note' | 'reflection';
 export type ContentStatus = 'pending' | 'extracting' | 'success' | 'failed' | 'skipped';
 export type SortOption = 'newest' | 'oldest' | 'title';
 export type ViewMode = 'list' | 'areas';


### PR DESCRIPTION
## Summary

- **Frontmatter improvements**: `areas` exported as `[[wikilinks]]` (enables Dataview queries + knowledge graph), `content_deck_id` added as future bidirectional sync anchor
- **Auto-export on mark done**: opt-in toggle in Settings — when enabled, marks a bookmark done and Obsidian opens to the new note silently (ContentDeck tab stays open via `window.open`)
- **Batch export**: "Export All Done" button in Settings with progress counter, done+unsynced count display, and clipboard fallback for Safari/iOS
- **Reflection notes**: `type: 'reflection'` notes now render under `## Reflection` section (distinct from `## Notes`)
- **arXiv**: uses `## Abstract` header + full `metadata.abstract` text instead of truncated excerpt
- **`NoteType` extended**: added `'reflection'` to the union; `NoteCard` gets purple/mirror-emoji config

## Test plan

- [ ] Settings: enter vault name → auto-export toggle appears
- [ ] Mark a YouTube bookmark done with auto-export on → Obsidian opens to new note, ContentDeck stays in foreground
- [ ] Open exported note → verify `areas` wikilinks and `content_deck_id` in frontmatter
- [ ] Export an arXiv bookmark → section header is `## Abstract`, full abstract text present
- [ ] Add a `reflection` note → export → appears under `## Reflection`, not `## Notes`
- [ ] Settings batch export → progress shows "Exporting X/Y...", bookmarks marked synced after
- [ ] Safari/iOS: batch export button label is "Copy All Done as Markdown"
- [ ] `npm run test` — 190 tests, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)