### PR TITLE
fix: gate values onboarding on areas existing

### DIFF
--- a/src/components/__tests__/HomePage.test.tsx
+++ b/src/components/__tests__/HomePage.test.tsx
@@ -102,7 +102,7 @@ function renderHome(props: Partial<typeof defaultProps> = {}) {
 const mockCycleStatusMutate = vi.fn();
 
 function setupDefaultMocks() {
-  vi.mocked(useTagAreas).mockReturnValue({ areas: [] } as unknown as ReturnType<
+  vi.mocked(useTagAreas).mockReturnValue({ areas: [], isLoading: false } as unknown as ReturnType<
     typeof useTagAreas
   >);
   vi.mocked(useUserValues).mockReturnValue({
@@ -244,10 +244,31 @@ describe('HomePage', () => {
     expect(screen.getByTestId('settings-modal')).toBeInTheDocument();
   });
 
-  it('10. shows onboarding modal when contentdeck_values is null', () => {
+  it('10. shows onboarding modal when contentdeck_values is null and areas exist', async () => {
     localStorage.removeItem('contentdeck_values');
+    vi.mocked(useTagAreas).mockReturnValue({
+      areas: [{ id: 'a1', name: 'Tech', emoji: '💻', color: 'blue', sort_order: 0, user_id: 'u1' }],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useTagAreas>);
     renderHome();
-    expect(screen.getByTestId('onboarding-modal')).toBeInTheDocument();
+    expect(await screen.findByTestId('onboarding-modal')).toBeInTheDocument();
+  });
+
+  it('10b. does not show onboarding modal when user has no areas', () => {
+    localStorage.removeItem('contentdeck_values');
+    // setupDefaultMocks already sets areas: []
+    renderHome();
+    expect(screen.queryByTestId('onboarding-modal')).not.toBeInTheDocument();
+  });
+
+  it('10c. does not show onboarding modal while areas are loading', () => {
+    localStorage.removeItem('contentdeck_values');
+    vi.mocked(useTagAreas).mockReturnValue({
+      areas: [],
+      isLoading: true,
+    } as unknown as ReturnType<typeof useTagAreas>);
+    renderHome();
+    expect(screen.queryByTestId('onboarding-modal')).not.toBeInTheDocument();
   });
 
   it('11. does not show onboarding modal when values exist in localStorage', () => {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -434,13 +434,11 @@ export function HomePage({ userEmail, onSignOut, isDemo }: HomePageProps) {
   const [mood, setMood] = useState<MoodMode>('default');
   const [now, setNow] = useState(() => new Date());
   const [showSettings, setShowSettings] = useState(false);
-  const [showOnboarding, setShowOnboarding] = useState(
-    () => localStorage.getItem('contentdeck_values') === null && !isDemo,
-  );
+  const [showOnboarding, setShowOnboarding] = useState(false);
   const [pendingDoneBookmark, setPendingDoneBookmark] = useState<Bookmark | null>(null);
   const [pendingReviewBookmark, setPendingReviewBookmark] = useState<Bookmark | null>(null);
 
-  const { areas } = useTagAreas();
+  const { areas, isLoading: areasLoading } = useTagAreas();
   const { setValues } = useUserValues();
   const { topPick, continueItem, quickWin } = useScoring(mood);
   const { isLoading, bookmarks, cycleStatus, addNote, updateBookmark } = useBookmarks();
@@ -451,6 +449,18 @@ export function HomePage({ userEmail, onSignOut, isDemo }: HomePageProps) {
     const id = setInterval(() => setNow(new Date()), 60_000);
     return () => clearInterval(id);
   }, []);
+
+  // Show onboarding only once areas have loaded and the user has at least one area
+  useEffect(() => {
+    if (
+      !areasLoading &&
+      areas.length > 0 &&
+      localStorage.getItem('contentdeck_values') === null &&
+      !isDemo
+    ) {
+      setShowOnboarding(true);
+    }
+  }, [areas, areasLoading, isDemo]);
 
   // Most recently saved unread bookmark that wasn't already surfaced as the primary pick.
   // ISO 8601 strings are lexicographically sortable — no Date parsing needed.


### PR DESCRIPTION
## Summary
- Values onboarding modal now only shows after `useTagAreas` finishes loading **and** the user has at least one area
- Previously fired immediately on mount for all new users, presenting a modal to prioritize areas that didn't exist yet
- Implemented via `useEffect` + `areasLoading` guard instead of `useState` initializer

## Tests
- Updated test 10: async `findByTestId` + areas mock required
- Added test 10b: no modal when areas empty
- Added test 10c: no modal while areas loading
- 263 tests passing

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)