### PR TITLE
fix: SW navigation timeout — Promise.race instead of AbortController (Safari iOS)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -36,34 +36,30 @@ self.addEventListener('fetch', (event) => {
     return
   }
 
-  // Network-first for navigation requests (HTML pages) with 4s timeout for Safari
-  // This prevents serving stale HTML that references old JS/CSS bundles
+  // Network-first for navigation requests (HTML pages) with 8s timeout
+  // Uses Promise.race instead of AbortController — AbortController in SW fetch
+  // is unreliable on iOS Safari (catch block may not fire, causing indefinite hang)
   if (event.request.mode === 'navigate') {
     event.respondWith(
-      (async () => {
-        const cached = await caches.match(event.request);
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 4000);
-
-        try {
-          const response = await fetch(event.request, { signal: controller.signal });
-          clearTimeout(timeoutId);
+      caches.match(event.request).then((cached) => {
+        const networkFetch = fetch(event.request).then((response) => {
           if (response.ok) {
-            const cache = await caches.open(CACHE_NAME);
-            cache.put(event.request, response.clone());
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, response.clone()))
           }
-          return response;
-        } catch {
-          clearTimeout(timeoutId);
-          if (cached) return cached;
-          return new Response('Offline', {
+          return response
+        })
+
+        const timeout = new Promise((resolve) =>
+          setTimeout(() => resolve(cached ?? new Response('Offline', {
             status: 503,
             headers: { 'Content-Type': 'text/plain' },
-          });
-        }
-      })()
-    );
-    return;
+          })), 8000)
+        )
+
+        return Promise.race([networkFetch, timeout])
+      })
+    )
+    return
   }
 
   // Stale-while-revalidate for other assets (JS, CSS, images, fonts)


### PR DESCRIPTION
## Problem

Safari iOS hangs on navigation (white screen indefinitely) because `AbortController.abort()` inside a service worker fetch is unreliable on iOS Safari — the `catch` block may not fire, leaving `event.respondWith()` unresolved until Safari's own timeout kicks in.

This explained why Chrome PWA worked fine (it cached on first install and served from cache) while Safari kept hitting the network and hanging.

## Fix

Replace `AbortController` + `signal` with `Promise.race([networkFetch, timeout])` — a Safari-compatible pattern that doesn't rely on fetch cancellation:

- Network fetch runs unconstrained (background)
- 8s timeout resolves with cached HTML (if available) or 503
- Whichever wins the race is served
- Network fetch still caches on success even if it loses the race

Timeout increased 4s → 8s: more headroom for cold starts without relying on abort.

## Why Chrome PWA worked

Chrome's service worker correctly handled `AbortController`, fell back to cached HTML on timeout, and served it. Safari never reached the catch block, so it never served the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)