### PR TITLE
fix: bottom nav is a static footer — kills the dead band below the tab bar

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -50,16 +50,15 @@ export default function AppShell({
         {/* Content Area */}
         <main
           id="main-content"
-          className="flex-1 overflow-y-auto"
-          style={{
-            paddingBottom: '44px',
-            overscrollBehavior: 'contain',
-          }}
+          className="flex-1 min-h-0 overflow-y-auto"
+          style={{ overscrollBehavior: 'contain' }}
         >
           {children}
         </main>
 
-        {/* Mobile Bottom Nav */}
+        {/* Mobile Bottom Nav — static footer in the flex column (never `fixed`:
+            iOS anchors fixed elements to the small viewport, leaving a dead band
+            under the bar; in-flow keeps it flush with the app container bottom) */}
         <MobileNav counts={counts} />
       </div>
     </div>

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -31,10 +31,11 @@ export default function MobileNav({ counts }: MobileNavProps) {
 
   return (
     <nav
-      className="lg:hidden fixed bottom-0 left-0 right-0 z-30 bg-surface-50 dark:bg-surface-950 border-t border-surface-200 dark:border-surface-800"
+      className="lg:hidden flex-none z-30 bg-surface-50 dark:bg-surface-950 border-t border-surface-200 dark:border-surface-800"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
       aria-label="Bottom navigation"
     >
-      <div className="flex h-[44px]">
+      <div className="flex h-[49px]">
         {tabs.map(({ status, label, icon: Icon, countKey }) => {
           const active = currentStatus === status;
           const count = counts[countKey];

--- a/src/components/modals/BulkActionBar.tsx
+++ b/src/components/modals/BulkActionBar.tsx
@@ -18,7 +18,7 @@ export default function BulkActionBar({
   if (selectedCount === 0) return null;
 
   return (
-    <div className="fixed bottom-[44px] lg:bottom-4 left-1/2 -translate-x-1/2 z-40 flex items-center gap-2 px-4 py-3 rounded-xl bg-surface-900 dark:bg-surface-100 text-white dark:text-surface-900 shadow-xl">
+    <div className="fixed bottom-[calc(57px+env(safe-area-inset-bottom,0px))] lg:bottom-4 left-1/2 -translate-x-1/2 z-40 flex items-center gap-2 px-4 py-3 rounded-xl bg-surface-900 dark:bg-surface-100 text-white dark:text-surface-900 shadow-xl">
       <span className="text-sm font-medium mr-2">{selectedCount} selected</span>
 
       <button


### PR DESCRIPTION
## Summary

Long-standing mobile issue (user-reported, multiple past attempts): the bottom Unread/Reading/Done bar floated above a dead white band, wasting screen space.

**Root cause:** MobileNav was `position: fixed`. iOS anchors fixed elements to the *small layout viewport* (the area excluding Safari's collapsible toolbar), so the bar could never reach the true bottom — no styling on a fixed element can claim that zone. Same bug class as the banner overlays fixed in #59.

**Fix:** the nav is now a static `flex-none` footer inside the app's flex column — flush with the bottom of the `100dvh` container we control, immune to viewport anchoring quirks. Native iOS tab bar treatment: 49px row (UIKit standard) + `padding-bottom: env(safe-area-inset-bottom)` so the bar's background extends under the home indicator with icons above it.

Also: `main` drops its 44px clearance hack (nav is in-flow now); BulkActionBar offset updated to clear the new bar.

## Test plan
- [x] format / lint (0 errors) / typecheck / 481 tests / build — all green
- [x] In-browser geometry verification at 390×844: `navBottom === window.innerHeight` (flush, zero dead space)
- [ ] Real-device check (iPhone): bar sits on the home indicator, icons above it

🤖 Generated with [Claude Code](https://claude.com/claude-code)