### PR TITLE
fix: bottom sheets swallowed touch scrolling — drag-dismiss from handle only

### DIFF
--- a/src/components/detail/DetailPanel.tsx
+++ b/src/components/detail/DetailPanel.tsx
@@ -5,6 +5,7 @@ import {
   useReducedMotion,
   useMotionValue,
   useTransform,
+  useDragControls,
 } from 'framer-motion';
 import { X, BookOpen } from 'lucide-react';
 import { SourceBadge } from '../ui/Badge';
@@ -57,6 +58,7 @@ export default function DetailPanel({
   // Drive backdrop opacity from live drag offset
   const dragY = useMotionValue(0);
   const backdropOpacity = useTransform(dragY, [0, 350], [0.5, 0]);
+  const dragControls = useDragControls();
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -174,6 +176,10 @@ export default function DetailPanel({
           exit={{ y: '100%' }}
           transition={transition}
           drag="y"
+          // drag="y" on the whole sheet swallows touch scrolling — dismissal
+          // drag must start from the handle/header only (dragControls)
+          dragListener={false}
+          dragControls={dragControls}
           dragConstraints={{ top: 0 }}
           dragElastic={0.1}
           dragMomentum={false}
@@ -192,13 +198,21 @@ export default function DetailPanel({
             }
           }}
         >
-          {/* Drag handle pill */}
-          <div className="flex justify-center pt-3 pb-1">
+          {/* Drag handle pill — dismissal drag starts here */}
+          <div
+            className="flex justify-center pt-3 pb-1"
+            style={{ touchAction: 'none' }}
+            onPointerDown={(e) => dragControls.start(e)}
+          >
             <div className="w-10 h-1 rounded-full bg-surface-300 dark:bg-surface-600" />
           </div>
 
           {/* Header */}
-          <div className="sticky top-0 flex items-center justify-between p-4 border-b border-surface-200 dark:border-surface-700 bg-surface-50 dark:bg-surface-900 rounded-t-2xl z-10">
+          <div
+            className="sticky top-0 flex items-center justify-between p-4 border-b border-surface-200 dark:border-surface-700 bg-surface-50 dark:bg-surface-900 rounded-t-2xl z-10"
+            style={{ touchAction: 'none' }}
+            onPointerDown={(e) => dragControls.start(e)}
+          >
             <div className="flex items-center gap-2 min-w-0 flex-1 mr-2">
               <SourceBadge source={bookmark.source_type} />
               <h2 className="text-sm font-semibold text-surface-900 dark:text-surface-100 truncate">

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback } from 'react';
-import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+import { motion, AnimatePresence, useReducedMotion, useDragControls } from 'framer-motion';
 import { X } from 'lucide-react';
 import { useIsMobile } from '../../hooks/useIsMobile';
 import {
@@ -23,6 +23,7 @@ export default function Modal({ open, onClose, title, children, size = 'md' }: M
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const isMobile = useIsMobile();
   const shouldReduceMotion = useReducedMotion();
+  const dragControls = useDragControls();
 
   const sizeClasses = {
     sm: 'max-w-sm',
@@ -130,6 +131,10 @@ export default function Modal({ open, onClose, title, children, size = 'md' }: M
             {...panelVariants}
             transition={transition}
             drag={isMobile ? 'y' : false}
+            // drag="y" on the whole panel swallows touch scrolling — dismissal
+            // drag must start from the handle/header only (dragControls)
+            dragListener={false}
+            dragControls={dragControls}
             dragConstraints={{ top: 0 }}
             dragElastic={0.05}
             dragMomentum={false}
@@ -145,14 +150,22 @@ export default function Modal({ open, onClose, title, children, size = 'md' }: M
               }
             }}
           >
-            {/* Drag handle pill — mobile only */}
+            {/* Drag handle pill — mobile only; dismissal drag starts here */}
             {isMobile && (
-              <div className="flex justify-center pt-3 pb-1">
+              <div
+                className="flex justify-center pt-3 pb-1"
+                style={{ touchAction: 'none' }}
+                onPointerDown={(e) => dragControls.start(e)}
+              >
                 <div className="w-10 h-1 rounded-full bg-surface-300 dark:bg-surface-600" />
               </div>
             )}
 
-            <div className="sticky top-0 flex items-center justify-between p-4 border-b border-surface-200 dark:border-surface-700 bg-surface-50 dark:bg-surface-900 rounded-t-2xl sm:rounded-t-2xl z-10">
+            <div
+              className="sticky top-0 flex items-center justify-between p-4 border-b border-surface-200 dark:border-surface-700 bg-surface-50 dark:bg-surface-900 rounded-t-2xl sm:rounded-t-2xl z-10"
+              style={isMobile ? { touchAction: 'none' } : undefined}
+              onPointerDown={isMobile ? (e) => dragControls.start(e) : undefined}
+            >
               <h2
                 id="modal-title"
                 className="text-lg font-semibold text-surface-900 dark:text-surface-100"


### PR DESCRIPTION
User-reported on device: Settings modal cannot scroll on iPhone. Root cause: framer-motion `drag=\"y\"` on the whole sheet panel captures all vertical touch gestures, starving `overflow-y-auto` — every overflowing modal has been unscrollable on touch since v3.9. Fixed in Modal + DetailPanel with `dragListener={false}` + `useDragControls` started from the handle pill / sticky header. ReaderModal already safe (`drag=\"x\"` + `dragDirectionLock`).

Pipeline green: 481 tests, lint 0 errors, build OK. Touch behavior needs real-device confirmation (mouse wheel can't reproduce the bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)