### PR TITLE
fix: adaptive safe-area insets — correct in both full-bleed and inset viewports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,8 +104,9 @@ export default function App() {
             >
               Skip to main content
             </a>
-            {/* Flex column so banners reserve layout space instead of overlaying app chrome */}
-            <div className="h-[100dvh] flex flex-col">
+            {/* Flex column so banners reserve layout space instead of overlaying app chrome.
+                --safe-top is 0 unless the viewport is full-bleed (see index.css). */}
+            <div className="h-[100dvh] flex flex-col" style={{ paddingTop: 'var(--safe-top)' }}>
               {isDemo ? <DemoBanner onSignIn={handleExitDemo} /> : <UpdateBanner />}
               <div className="flex-1 min-h-0">
                 <Suspense fallback={<LoadingSpinner />}>

--- a/src/components/auth/AuthScreen.tsx
+++ b/src/components/auth/AuthScreen.tsx
@@ -62,7 +62,10 @@ export default function AuthScreen({ onDemo, onMagicLink, onGoogle, onGitHub }: 
   }
 
   return (
-    <div className="h-[100dvh] overflow-y-auto overscroll-contain bg-surface-50 dark:bg-surface-950">
+    <div
+      className="h-[100dvh] overflow-y-auto overscroll-contain bg-surface-50 dark:bg-surface-950"
+      style={{ paddingTop: 'var(--safe-top)', paddingBottom: 'var(--safe-bottom)' }}
+    >
       <div className="min-h-full flex items-center justify-center px-4 py-12">
         <div className="w-full max-w-2xl space-y-8">
           {/* Header */}

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -32,6 +32,7 @@ export default function MobileNav({ counts }: MobileNavProps) {
   return (
     <nav
       className="lg:hidden flex-none z-30 bg-surface-50 dark:bg-surface-950 border-t border-surface-200 dark:border-surface-800"
+      style={{ paddingBottom: 'var(--safe-bottom)' }}
       aria-label="Bottom navigation"
     >
       <div className="flex h-[49px]">

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -26,6 +26,7 @@ function ViewportDiagnostics() {
       (navigator as Navigator & { standalone?: boolean }).standalone === true;
     setInfo({
       standalone: String(standalone),
+      'fullbleed mode': String(document.documentElement.classList.contains('vp-fullbleed')),
       'window.innerHeight': String(window.innerHeight),
       'html.clientHeight': String(document.documentElement.clientHeight),
       'visualViewport.height': String(Math.round(window.visualViewport?.height ?? 0)),

--- a/src/components/reader/ReaderModal.tsx
+++ b/src/components/reader/ReaderModal.tsx
@@ -341,6 +341,7 @@ export default function ReaderModal({
       {/* Header */}
       <header
         className={`flex items-center justify-between gap-3 px-4 py-2 border-b ${headerThemeClasses} shrink-0`}
+        style={{ paddingTop: 'calc(8px + var(--safe-top))' }}
       >
         {/* Left: icon + title */}
         <div className="flex items-center gap-2 min-w-0">
@@ -562,6 +563,7 @@ export default function ReaderModal({
       {/* Footer */}
       <footer
         className={`flex items-center justify-between px-4 py-2 border-t ${headerThemeClasses} shrink-0`}
+        style={{ paddingBottom: 'calc(8px + var(--safe-bottom))' }}
       >
         <span className={`text-xs ${subtleText}`}>
           {hasContent && minutesRemaining !== null && minutesRemaining > 0

--- a/src/index.css
+++ b/src/index.css
@@ -152,8 +152,18 @@ select {
   }
 }
 
-/* Safe area CSS variables */
+/* Safe area CSS variables — zero unless the viewport is truly full-bleed.
+   iOS standalone installs in status-bar-inset mode (viewport already excludes
+   the unsafe zones) still report nonzero env() insets; padding for them there
+   double-counts. main.tsx toggles .vp-fullbleed when innerHeight === screen.height. */
 :root {
+  --safe-top: 0px;
+  --safe-bottom: 0px;
+  --safe-left: 0px;
+  --safe-right: 0px;
+}
+
+html.vp-fullbleed {
   --safe-top: env(safe-area-inset-top, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
   --safe-left: env(safe-area-inset-left, 0px);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,16 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 
+// Safe-area insets must only be applied when the viewport is truly full-bleed.
+// iOS standalone installs in status-bar-inset mode (viewport already shrunk by
+// the OS) still report nonzero env() insets — padding for them double-counts.
+// .vp-fullbleed gates the --safe-* variables in index.css.
+function syncViewportMode() {
+  document.documentElement.classList.toggle('vp-fullbleed', window.innerHeight === screen.height);
+}
+syncViewportMode();
+window.addEventListener('resize', syncViewportMode);
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -592,11 +592,11 @@ export function HomePage({ userEmail, onSignOut, isDemo }: HomePageProps) {
   return (
     <div
       className="h-full overflow-y-auto bg-surface-50 dark:bg-surface-950"
-      style={{ paddingTop: 'env(safe-area-inset-top, 0px)', overscrollBehavior: 'contain' }}
+      style={{ overscrollBehavior: 'contain' }}
     >
       <div
         className="max-w-lg mx-auto px-4 py-6"
-        style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 16px)' }}
+        style={{ paddingBottom: 'calc(var(--safe-bottom) + 16px)' }}
       >
         <main id="main-content">
           <HomeHeader


### PR DESCRIPTION
Finding #9 resolved by device diagnostics: the installed PWA runs in status-bar-inset mode (innerHeight 793 vs screen.height 852 — install predates the v3.8 `black-translucent` metas, and iOS snapshots config at install time) while still reporting nonzero env() insets. Blanket env() padding double-counts there; omitting it breaks proper full-bleed installs.

`--safe-*` vars are now 0 by default and resolve to env() only under `html.vp-fullbleed`, toggled by main.tsx when `innerHeight === screen.height`. All consumers wired (app column, AuthScreen, MobileNav, HomePage, ReaderModal header/footer; Modal + DetailPanel already used the vars). Bonus fix: HomePage was over-padded 59px in inset mode.

User action after merge: remove + re-add the home-screen icon → fresh install picks up full-bleed config → native edge-to-edge layout. Current inset installs keep working (vars = 0, today's exact layout).

Pipeline green: 481 tests, lint 0 errors, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)