### PR TITLE
fix: apply safe-area insets unconditionally — vp-fullbleed gate misfired on device

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -152,18 +152,12 @@ select {
   }
 }
 
-/* Safe area CSS variables — zero unless the viewport is truly full-bleed.
-   iOS standalone installs in status-bar-inset mode (viewport already excludes
-   the unsafe zones) still report nonzero env() insets; padding for them there
-   double-counts. main.tsx toggles .vp-fullbleed when innerHeight === screen.height. */
+/* Safe area CSS variables.
+   Applied unconditionally: fresh full-bleed PWA installs (black-translucent +
+   viewport-fit=cover) report correct env() insets. The earlier .vp-fullbleed
+   JS gate (innerHeight === screen.height) misfired on real devices — the class
+   is kept in main.tsx purely as a diagnostics signal, not a CSS switch. */
 :root {
-  --safe-top: 0px;
-  --safe-bottom: 0px;
-  --safe-left: 0px;
-  --safe-right: 0px;
-}
-
-html.vp-fullbleed {
   --safe-top: env(safe-area-inset-top, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
   --safe-left: env(safe-area-inset-left, 0px);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,10 +5,9 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 
-// Safe-area insets must only be applied when the viewport is truly full-bleed.
-// iOS standalone installs in status-bar-inset mode (viewport already shrunk by
-// the OS) still report nonzero env() insets — padding for them double-counts.
-// .vp-fullbleed gates the --safe-* variables in index.css.
+// Diagnostics-only signal (shown in Settings → Viewport diagnostics): true when
+// the viewport spans the full screen. NOT used as a CSS gate — the check proved
+// unreliable across iOS standalone modes; --safe-* vars apply env() directly.
 function syncViewportMode() {
   document.documentElement.classList.toggle('vp-fullbleed', window.innerHeight === screen.height);
 }


### PR DESCRIPTION
Post-reinstall device screenshot showed the app is now truly full-bleed but the `innerHeight === screen.height` gate from #63 did not trigger — `--safe-top` stayed 0, status bar overlapped the MobileHeader (settings gear unreachable under the battery/wifi icons).

The gate only existed to protect stale status-bar-inset installs, which no longer exist. `--safe-*` now resolve to `env()` unconditionally (standard full-bleed PWA treatment). `vp-fullbleed` class kept as a diagnostics-only readout.

Pipeline green: 481 tests, lint 0 errors, build OK. Real-device confirmation next (diagnostics screenshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)