### PR TITLE
fix: reclaim ~120pt of mobile screen — drop bogus top inset, replace 100dvh with height:100%

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ const DEMO_KEY = 'contentdeck_demo';
 
 function LoadingSpinner() {
   return (
-    <div className="min-h-[100dvh] flex items-center justify-center bg-surface-50 dark:bg-surface-950">
+    <div className="min-h-full flex items-center justify-center bg-surface-50 dark:bg-surface-950">
       <Spinner size={32} />
     </div>
   );
@@ -105,8 +105,9 @@ export default function App() {
               Skip to main content
             </a>
             {/* Flex column so banners reserve layout space instead of overlaying app chrome.
-                --safe-top is 0 unless the viewport is full-bleed (see index.css). */}
-            <div className="h-[100dvh] flex flex-col" style={{ paddingTop: 'var(--safe-top)' }}>
+                h-full (not 100dvh): iOS standalone under-computes dvh. No top padding:
+                the OS already insets the webview below the status bar. */}
+            <div className="h-full flex flex-col">
               {isDemo ? <DemoBanner onSignIn={handleExitDemo} /> : <UpdateBanner />}
               <div className="flex-1 min-h-0">
                 <Suspense fallback={<LoadingSpinner />}>

--- a/src/components/auth/AuthScreen.tsx
+++ b/src/components/auth/AuthScreen.tsx
@@ -63,8 +63,8 @@ export default function AuthScreen({ onDemo, onMagicLink, onGoogle, onGitHub }: 
 
   return (
     <div
-      className="h-[100dvh] overflow-y-auto overscroll-contain bg-surface-50 dark:bg-surface-950"
-      style={{ paddingTop: 'var(--safe-top)', paddingBottom: 'var(--safe-bottom)' }}
+      className="h-full overflow-y-auto overscroll-contain bg-surface-50 dark:bg-surface-950"
+      style={{ paddingBottom: 'var(--safe-bottom)' }}
     >
       <div className="min-h-full flex items-center justify-center px-4 py-12">
         <div className="w-full max-w-2xl space-y-8">

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -17,10 +17,11 @@ function ViewportDiagnostics() {
   useEffect(() => {
     const probe = document.createElement('div');
     probe.style.cssText =
-      'position:fixed;visibility:hidden;pointer-events:none;' +
+      'position:fixed;visibility:hidden;pointer-events:none;height:100dvh;' +
       'padding-top:env(safe-area-inset-top,0px);padding-bottom:env(safe-area-inset-bottom,0px)';
     document.body.appendChild(probe);
     const cs = getComputedStyle(probe);
+    const dvhPx = probe.getBoundingClientRect().height;
     const standalone =
       window.matchMedia('(display-mode: standalone)').matches ||
       (navigator as Navigator & { standalone?: boolean }).standalone === true;
@@ -30,6 +31,7 @@ function ViewportDiagnostics() {
       'window.innerHeight': String(window.innerHeight),
       'html.clientHeight': String(document.documentElement.clientHeight),
       'visualViewport.height': String(Math.round(window.visualViewport?.height ?? 0)),
+      '100dvh measures as': `${Math.round(dvhPx)}px`,
       'screen.height': String(screen.height),
       'safe-area top / bottom': `${cs.paddingTop} / ${cs.paddingBottom}`,
     });

--- a/src/components/reader/ReaderModal.tsx
+++ b/src/components/reader/ReaderModal.tsx
@@ -341,7 +341,6 @@ export default function ReaderModal({
       {/* Header */}
       <header
         className={`flex items-center justify-between gap-3 px-4 py-2 border-b ${headerThemeClasses} shrink-0`}
-        style={{ paddingTop: 'calc(8px + var(--safe-top))' }}
       >
         {/* Left: icon + title */}
         <div className="flex items-center gap-2 min-w-0">

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -32,7 +32,7 @@ export default class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.hasError) {
       return (
-        <div className="flex items-center justify-center min-h-[100dvh] bg-surface-50 dark:bg-surface-950 p-4">
+        <div className="flex items-center justify-center min-h-full bg-surface-50 dark:bg-surface-950 p-4">
           <div className="max-w-md text-center space-y-4">
             <h1 className="text-xl font-bold text-surface-900 dark:text-surface-100">
               Something went wrong

--- a/src/index.css
+++ b/src/index.css
@@ -101,7 +101,10 @@
 /* Base styles — native app foundation */
 html {
   scroll-behavior: smooth;
-  height: 100dvh;
+  /* height: 100% (not 100dvh) — iOS standalone computes 100dvh as
+     viewport minus the (bogus) top safe-area inset, losing 59px of usable
+     height. Percentages resolve against the true viewport. */
+  height: 100%;
   overflow: hidden;
   overscroll-behavior: none;
   touch-action: manipulation; /* disables double-tap zoom */
@@ -124,10 +127,14 @@ html.sepia {
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  height: 100dvh;
+  height: 100%;
   overflow: hidden;
   overscroll-behavior: none;
   background-color: inherit;
+}
+
+#root {
+  height: 100%;
 }
 
 /* Prevent iOS auto-zoom on input focus (triggers when font-size < 16px) */


### PR DESCRIPTION
Final round of finding #9, driven by fresh-install device diagnostics:

1. **env(safe-area-inset-top) lies in this standalone mode** — reports 59px while the OS already places the webview below the status bar (innerHeight 793 = 852 − 59). Our top padding double-counted. Removed everywhere.
2. **100dvh lies too** — measures 734px, 59px shorter than the real 793px viewport, so the app column didn't even fill its own window. Replaced with a `height: 100%` chain (html → body → #root → column), which resolves against the true viewport.
3. Bottom `env()` padding kept — the home indicator genuinely overlaps the webview bottom.

Net effect on device: ~120pt of vertical space reclaimed; header directly below status bar; tab bar at the true bottom with icons above the home indicator.

Verified in-browser: #root fills the viewport exactly, nav flush at bottom, 481 tests green, lint 0 errors. Device confirmation next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)