### PR TITLE
fix: restore original compact bottom bar + HomePage top offset

### DIFF
--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -32,10 +32,11 @@ export default function MobileNav({ counts }: MobileNavProps) {
   return (
     <nav
       className="lg:hidden flex-none z-30 bg-surface-50 dark:bg-surface-950 border-t border-surface-200 dark:border-surface-800"
-      style={{ paddingBottom: 'var(--safe-bottom)' }}
       aria-label="Bottom navigation"
     >
-      <div className="flex h-[49px]">
+      {/* 44px row, no safe-area pad — matches the original compact bar (the
+          home-indicator overlap was never a real-use problem; reclaim the space) */}
+      <div className="flex h-[44px]">
         {tabs.map(({ status, label, icon: Icon, countKey }) => {
           const active = currentStatus === status;
           const count = counts[countKey];

--- a/src/components/modals/BulkActionBar.tsx
+++ b/src/components/modals/BulkActionBar.tsx
@@ -18,7 +18,7 @@ export default function BulkActionBar({
   if (selectedCount === 0) return null;
 
   return (
-    <div className="fixed bottom-[calc(57px+env(safe-area-inset-bottom,0px))] lg:bottom-4 left-1/2 -translate-x-1/2 z-40 flex items-center gap-2 px-4 py-3 rounded-xl bg-surface-900 dark:bg-surface-100 text-white dark:text-surface-900 shadow-xl">
+    <div className="fixed bottom-[44px] lg:bottom-4 left-1/2 -translate-x-1/2 z-40 flex items-center gap-2 px-4 py-3 rounded-xl bg-surface-900 dark:bg-surface-100 text-white dark:text-surface-900 shadow-xl">
       <span className="text-sm font-medium mr-2">{selectedCount} selected</span>
 
       <button

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -592,7 +592,7 @@ export function HomePage({ userEmail, onSignOut, isDemo }: HomePageProps) {
   return (
     <div
       className="h-full overflow-y-auto bg-surface-50 dark:bg-surface-950"
-      style={{ overscrollBehavior: 'contain' }}
+      style={{ overscrollBehavior: 'contain', paddingTop: 'var(--safe-top)' }}
     >
       <div
         className="max-w-lg mx-auto px-4 py-6"


### PR DESCRIPTION
Closes the finding #9 arc per user review against the day-one benchmark (mobile-light.jpeg):

1. **Bottom bar back to original geometry** — 44px row, no safe-area padding. The 34px indicator pad + 49px row added ~39px of waste over the pre-overhaul bar; months of real usage proved the compact bar fine. The 59pt strip below the webview is OS-owned (identical day one vs now) and not claimable.
2. **HomePage top offset restored** (`var(--safe-top)`) — greeting was sliding under the status bar clock after #63/#65 stripped it.

Everything genuinely won in this arc stays: static (non-fixed) chrome, scrollable bottom sheets, handle-only drag-dismiss, banner layout space, auth scroll.

Pipeline green: 481 tests, lint 0 errors, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)