### PR TITLE
chore: remove temporary viewport diagnostics — finding #9 confirmed on device

### DIFF
--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -9,53 +9,6 @@ import Button from '../ui/Button';
 import TokenManager from '../settings/TokenManager';
 import FeedbackList from '../settings/FeedbackList';
 
-// TEMP: surfaces the viewport numbers the device actually reports, so the iOS
-// bottom-bar dead zone (overhaul finding #9) can be diagnosed from a screenshot.
-function ViewportDiagnostics() {
-  const [info, setInfo] = useState<Record<string, string> | null>(null);
-
-  useEffect(() => {
-    const probe = document.createElement('div');
-    probe.style.cssText =
-      'position:fixed;visibility:hidden;pointer-events:none;height:100dvh;' +
-      'padding-top:env(safe-area-inset-top,0px);padding-bottom:env(safe-area-inset-bottom,0px)';
-    document.body.appendChild(probe);
-    const cs = getComputedStyle(probe);
-    const dvhPx = probe.getBoundingClientRect().height;
-    const standalone =
-      window.matchMedia('(display-mode: standalone)').matches ||
-      (navigator as Navigator & { standalone?: boolean }).standalone === true;
-    setInfo({
-      standalone: String(standalone),
-      'fullbleed mode': String(document.documentElement.classList.contains('vp-fullbleed')),
-      'window.innerHeight': String(window.innerHeight),
-      'html.clientHeight': String(document.documentElement.clientHeight),
-      'visualViewport.height': String(Math.round(window.visualViewport?.height ?? 0)),
-      '100dvh measures as': `${Math.round(dvhPx)}px`,
-      'screen.height': String(screen.height),
-      'safe-area top / bottom': `${cs.paddingTop} / ${cs.paddingBottom}`,
-    });
-    document.body.removeChild(probe);
-  }, []);
-
-  if (!info) return null;
-  return (
-    <section className="pt-2 border-t border-surface-200 dark:border-surface-800">
-      <h3 className="text-xs font-semibold text-surface-500 dark:text-surface-400 mb-1.5">
-        Viewport diagnostics (temporary)
-      </h3>
-      <dl className="font-mono text-[11px] leading-relaxed text-surface-500 dark:text-surface-400">
-        {Object.entries(info).map(([k, v]) => (
-          <div key={k} className="flex justify-between gap-2">
-            <dt>{k}</dt>
-            <dd className="text-surface-700 dark:text-surface-200">{v}</dd>
-          </div>
-        ))}
-      </dl>
-    </section>
-  );
-}
-
 interface SettingsModalProps {
   open: boolean;
   onClose: () => void;
@@ -403,10 +356,6 @@ export default function SettingsModal({
               </div>
             </section>
           )}
-
-          {/* TEMP: viewport diagnostics for the iOS bottom-bar dead-zone investigation
-              (overhaul finding #9). Remove once the mobile nav fix is confirmed on device. */}
-          <ViewportDiagnostics />
 
           {/* Info */}
           <section className="pt-2 border-t border-surface-200 dark:border-surface-800">

--- a/src/index.css
+++ b/src/index.css
@@ -159,11 +159,11 @@ select {
   }
 }
 
-/* Safe area CSS variables.
-   Applied unconditionally: fresh full-bleed PWA installs (black-translucent +
-   viewport-fit=cover) report correct env() insets. The earlier .vp-fullbleed
-   JS gate (innerHeight === screen.height) misfired on real devices — the class
-   is kept in main.tsx purely as a diagnostics signal, not a CSS switch. */
+/* Safe area CSS variables. CAUTION (finding #9, June 2026): iOS standalone
+   inset reporting lies — installs run status-bar-inset (viewport already
+   excludes the top zone) while still reporting a 59px top inset, and 100dvh
+   under-measures. Consume these vars only with real-device verification;
+   the app shell sizes via the height:100% chain, never dvh. */
 :root {
   --safe-top: env(safe-area-inset-top, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,15 +5,6 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 
-// Diagnostics-only signal (shown in Settings → Viewport diagnostics): true when
-// the viewport spans the full screen. NOT used as a CSS gate — the check proved
-// unreliable across iOS standalone modes; --safe-* vars apply env() directly.
-function syncViewportMode() {
-  document.documentElement.classList.toggle('vp-fullbleed', window.innerHeight === screen.height);
-}
-syncViewportMode();
-window.addEventListener('resize', syncViewportMode);
-
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {


### PR DESCRIPTION
User confirmed the restored layout on device — the diagnostics panel (Settings) and the diagnostics-only `vp-fullbleed` toggle in main.tsx are no longer needed. iOS viewport caveats remain documented in `index.css` and `docs/plan/overhaul-2026-06.md`.

Pipeline green: 481 tests, lint 0 errors, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)